### PR TITLE
fix(fnf): Particle effects stuck on one color shade

### DIFF
--- a/app/(app)/flames/components/flame-card/effects/EffectsRenderer.tsx
+++ b/app/(app)/flames/components/flame-card/effects/EffectsRenderer.tsx
@@ -25,7 +25,7 @@ export function EffectsRenderer({
               <ParticleEmbers
                 key={effect.type}
                 state={state}
-                color={colors.light}
+                colors={colors}
                 config={effect}
               />
             );
@@ -34,7 +34,7 @@ export function EffectsRenderer({
               <GeometricSmoke
                 key={effect.type}
                 state={state}
-                color={colors.medium}
+                colors={colors}
                 config={effect}
               />
             );

--- a/app/(app)/flames/components/flame-card/effects/GeometricSmoke.tsx
+++ b/app/(app)/flames/components/flame-card/effects/GeometricSmoke.tsx
@@ -10,14 +10,13 @@ import {
   getParticleIntensity,
   shouldShowParticles,
 } from './particles';
-import type { SmokeEffectConfig } from './types';
+import type { ShapeColors, SmokeEffectConfig } from './types';
 
 interface SmokeParticle extends Particle {
   rotation: number;
-  isGrey: boolean;
 }
 
-const GREY_COLORS = ['#6b7280', '#9ca3af', '#4b5563', '#d1d5db'];
+const GREY_SHADES = ['#6b7280', '#9ca3af', '#4b5563', '#d1d5db'];
 
 const SMOKE_PARTICLE_CONFIG = {
   xRange: { min: 30, max: 70 },
@@ -26,6 +25,14 @@ const SMOKE_PARTICLE_CONFIG = {
   durationRange: { min: 2.5, max: 4.5 },
   driftRange: { min: -15, max: 15 },
 } as const;
+
+/** Mix of flame color shades and grey shades for natural-looking smoke */
+const SMOKE_PALETTE = (colors: ShapeColors) => [
+  colors.medium,
+  colors.dark,
+  colors.medium,
+  ...GREY_SHADES,
+] as const;
 
 function createSmokeParticle(
   index: number,
@@ -38,7 +45,6 @@ function createSmokeParticle(
     ...base,
     size: baseSize * base.size * sizeMultiplier,
     rotation: (hash % 90) - 45,
-    isGrey: index % 3 === 0,
   };
 }
 
@@ -46,7 +52,7 @@ interface GeometricSmokeProps extends BaseParticleProps {
   config: SmokeEffectConfig;
 }
 
-export function GeometricSmoke({ state, color, config }: GeometricSmokeProps) {
+export function GeometricSmoke({ state, colors, config }: GeometricSmokeProps) {
   const shouldReduceMotion = useReducedMotion();
   const showSmoke = shouldShowParticles(state) || state === 'sealed';
   const { baseSize, states } = config;
@@ -64,6 +70,7 @@ export function GeometricSmoke({ state, color, config }: GeometricSmokeProps) {
   }
 
   const { opacity, speed } = getParticleIntensity(state);
+  const palette = SMOKE_PALETTE(colors);
 
   return (
     <div
@@ -71,46 +78,40 @@ export function GeometricSmoke({ state, color, config }: GeometricSmokeProps) {
       className="pointer-events-none absolute inset-0 scale-75 md:scale-100"
     >
       <AnimatePresence>
-        {particles.map((particle) => {
-          const particleColor = particle.isGrey
-            ? GREY_COLORS[particle.id % GREY_COLORS.length]
-            : color;
-
-          return (
-            <motion.div
-              key={particle.id}
-              className="absolute"
-              style={{
-                left: `${particle.x}%`,
-                bottom: '35%',
-                width: particle.size,
-                height: particle.size,
-                backgroundColor: particleColor,
-                opacity,
-              }}
-              initial={{
-                y: 0,
-                x: 0,
-                opacity: 0,
-                rotate: 0,
-                scale: 0.5,
-              }}
-              animate={{
-                y: [-10, -80, -140],
-                x: [0, particle.drift * 0.5, particle.drift],
-                opacity: [0, opacity, opacity * 0.6, 0],
-                rotate: [0, particle.rotation * 0.5, particle.rotation],
-                scale: [0.5, 1, 1.3, 0.8],
-              }}
-              transition={{
-                duration: particle.duration * speed,
-                delay: particle.delay,
-                repeat: Infinity,
-                ease: 'easeOut',
-              }}
-            />
-          );
-        })}
+        {particles.map((particle) => (
+          <motion.div
+            key={particle.id}
+            className="absolute"
+            style={{
+              left: `${particle.x}%`,
+              bottom: '35%',
+              width: particle.size,
+              height: particle.size,
+              backgroundColor: palette[particle.colorIndex % palette.length],
+              opacity,
+            }}
+            initial={{
+              y: 0,
+              x: 0,
+              opacity: 0,
+              rotate: 0,
+              scale: 0.5,
+            }}
+            animate={{
+              y: [-10, -80, -140],
+              x: [0, particle.drift * 0.5, particle.drift],
+              opacity: [0, opacity, opacity * 0.6, 0],
+              rotate: [0, particle.rotation * 0.5, particle.rotation],
+              scale: [0.5, 1, 1.3, 0.8],
+            }}
+            transition={{
+              duration: particle.duration * speed,
+              delay: particle.delay,
+              repeat: Infinity,
+              ease: 'easeOut',
+            }}
+          />
+        ))}
       </AnimatePresence>
     </div>
   );

--- a/app/(app)/flames/components/flame-card/effects/ParticleEmbers.tsx
+++ b/app/(app)/flames/components/flame-card/effects/ParticleEmbers.tsx
@@ -9,13 +9,19 @@ import {
   getParticleIntensity,
   shouldShowParticles,
 } from './particles';
-import type { EmberEffectConfig } from './types';
+import type { EmberEffectConfig, ShapeColors } from './types';
 
 interface ParticleEmbersProps extends BaseParticleProps {
   config: EmberEffectConfig;
 }
 
-export function ParticleEmbers({ state, color, config }: ParticleEmbersProps) {
+const EMBER_PALETTE = (colors: ShapeColors) => [
+  colors.light,
+  colors.light,
+  colors.medium,
+] as const;
+
+export function ParticleEmbers({ state, colors, config }: ParticleEmbersProps) {
   const shouldReduceMotion = useReducedMotion();
   const showEmbers = shouldShowParticles(state);
   const { states } = config;
@@ -34,6 +40,7 @@ export function ParticleEmbers({ state, color, config }: ParticleEmbersProps) {
   }
 
   const { opacity, speed } = getParticleIntensity(state, {});
+  const palette = EMBER_PALETTE(colors);
 
   return (
     <div
@@ -50,7 +57,7 @@ export function ParticleEmbers({ state, color, config }: ParticleEmbersProps) {
               bottom: '40%',
               width: particle.size,
               height: particle.size,
-              backgroundColor: color,
+              backgroundColor: palette[particle.colorIndex % palette.length],
             }}
             initial={{ opacity: 0, y: 0 }}
             animate={{

--- a/app/(app)/flames/components/flame-card/effects/particles/types.ts
+++ b/app/(app)/flames/components/flame-card/effects/particles/types.ts
@@ -1,4 +1,5 @@
 import type { FlameState } from '@/app/(app)/flames/utils/types';
+import type { ShapeColors } from '../types';
 
 /** Base particle properties shared by all particle types */
 export interface Particle {
@@ -8,6 +9,8 @@ export interface Particle {
   delay: number;
   duration: number;
   drift: number;
+  /** Deterministic index for picking a color shade from a palette */
+  colorIndex: number;
 }
 
 export interface ParticleStateConfig {
@@ -25,5 +28,5 @@ export interface AnimationIntensity {
 
 export interface BaseParticleProps {
   state: FlameState;
-  color: string;
+  colors: ShapeColors;
 }

--- a/app/(app)/flames/components/flame-card/effects/particles/utils.ts
+++ b/app/(app)/flames/components/flame-card/effects/particles/utils.ts
@@ -43,6 +43,9 @@ export function generateBaseParticle(
   const durationRange = config?.durationRange ?? { min: 1.5, max: 2.5 };
   const driftRange = config?.driftRange ?? { min: -10, max: 10 };
 
+  // Use a different seed for color so it doesn't correlate with position/size
+  const colorHash = generateHash(index, seed + 77);
+
   return {
     id: index,
     x: xRange.min + (hash % (xRange.max - xRange.min)),
@@ -55,6 +58,7 @@ export function generateBaseParticle(
       durationRange.min +
       ((hash % 1000) / 1000) * (durationRange.max - durationRange.min),
     drift: driftRange.min + (hash % (driftRange.max - driftRange.min + 1)),
+    colorIndex: colorHash,
   };
 }
 


### PR DESCRIPTION
Previously, the particle generation looked nicer because it would randomly select from an array of available colour shades, but during refactoring we had at some point hardcoded it to one shade. This PR brings back procedurally generated particle colours.