### PR TITLE
polish(fnf): Improve styling of `FlameCard` in sealed state

### DIFF
--- a/app/(app)/flames/components/FlameCard.tsx
+++ b/app/(app)/flames/components/FlameCard.tsx
@@ -174,7 +174,9 @@ export function FlameCard({
           boxShadow: '0 0 15px #fbbf2450, 0 0 30px #fbbf2425',
           borderColor: '#fbbf24',
         }
-      : {};
+      : isSealed
+        ? { borderColor: '#64748b50' }
+        : {};
 
   const fuelMinutes = Math.floor(elapsedSeconds / 60);
 
@@ -207,7 +209,7 @@ export function FlameCard({
           'border-slate-200 bg-linear-to-b from-white to-slate-50 text-slate-900',
           'dark:border-white/10 dark:from-slate-900 dark:to-slate-950 dark:text-white',
           'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 cursor-pointer',
-          isSealed && 'cursor-default opacity-40',
+          isSealed && 'cursor-default',
           isFuelBlocked && 'cursor-default opacity-40',
           isBlocked && 'cursor-default opacity-40',
           isLoading && 'cursor-wait',
@@ -223,7 +225,9 @@ export function FlameCard({
         {...(canSeal || isSealing ? longPress.handlers : {})}
       >
         {/* Header - Name and Level */}
-        <div className="px-2 pt-2 sm:px-3 sm:pt-3">
+        <div
+          className={cn('px-2 pt-2 sm:px-3 sm:pt-3', isSealed && 'opacity-50')}
+        >
           <h3 className="truncate text-center text-xs font-semibold leading-tight sm:text-sm md:text-base">
             {flame.name}
           </h3>
@@ -251,12 +255,14 @@ export function FlameCard({
         {/* Footer - Timer, Progress, State */}
         <div className="flex flex-col gap-1 bg-slate-200/70 px-2 py-2 dark:bg-black/30 sm:gap-1.5 sm:px-3 sm:py-3">
           {flame.tracking_type === 'time' && targetSeconds > 0 && (
-            <TimerDisplay
-              elapsedSeconds={elapsedSeconds}
-              targetSeconds={targetSeconds}
-              state={state}
-              color={colors.light}
-            />
+            <div className={cn(isSealed && 'opacity-40')}>
+              <TimerDisplay
+                elapsedSeconds={elapsedSeconds}
+                targetSeconds={targetSeconds}
+                state={state}
+                color={colors.light}
+              />
+            </div>
           )}
           {flame.tracking_type === 'time' && targetSeconds > 0 && (
             <ProgressBar progress={progress} state={state} colors={colors} />
@@ -266,10 +272,24 @@ export function FlameCard({
               'text-center text-[10px] sm:text-xs',
               canSeal || isSealing
                 ? 'font-medium text-amber-500'
-                : 'text-slate-500 dark:text-white/50',
+                : isSealed
+                  ? 'font-medium'
+                  : 'text-slate-500 dark:text-white/50',
             )}
           >
-            {getStateText() ?? '\u00A0'}
+            {isSealed ? (
+              <span
+                className="bg-clip-text text-transparent"
+                style={{
+                  backgroundImage:
+                    'linear-gradient(to right, #d97706, #fbbf24, #fde68a, #fbbf24, #d97706)',
+                }}
+              >
+                {getStateText()}
+              </span>
+            ) : (
+              (getStateText() ?? '\u00A0')
+            )}
           </div>
         </div>
 

--- a/app/(app)/flames/components/flame-card/ProgressBar.tsx
+++ b/app/(app)/flames/components/flame-card/ProgressBar.tsx
@@ -13,21 +13,29 @@ interface ProgressBarProps {
   };
 }
 
+const SEALED_BAR_GRADIENT =
+  'linear-gradient(to right, #92400e, #d97706, #f59e0b, #fbbf24)';
+
 export function ProgressBar({ progress, state, colors }: ProgressBarProps) {
   const shouldReduceMotion = useReducedMotion();
   const isActive = state === 'burning';
+  const isSealed = state === 'sealed';
 
-  const percentage = Math.round(progress * 100);
+  const percentage = isSealed ? 100 : Math.round(progress * 100);
 
   return (
     <div className="relative h-1.5 w-full overflow-hidden rounded-full bg-slate-200 dark:bg-white/10 sm:h-2">
       <motion.div
         className="absolute inset-y-0 left-0 rounded-full"
         style={{
-          background: `linear-gradient(to right, ${colors.dark}, ${colors.medium}, ${colors.light})`,
+          background: isSealed
+            ? SEALED_BAR_GRADIENT
+            : `linear-gradient(to right, ${colors.dark}, ${colors.medium}, ${colors.light})`,
           boxShadow: isActive
             ? `0 0 8px ${colors.medium}, 0 0 16px ${colors.medium}40`
-            : 'none',
+            : isSealed
+              ? '0 0 6px #d9770640'
+              : 'none',
         }}
         initial={false}
         animate={{


### PR DESCRIPTION
- Progress bar goes to full regardless of how much fuel was used, and has a golden colour
- Sealed text is shiny gold
- Opacity of the Flame is not dimmed, so the beauty of the flame animations remain visible 

<img width="932" height="523" alt="image" src="https://github.com/user-attachments/assets/eab45584-387c-4f6b-8a58-45aece6312fb" />
