### PR TITLE
feat(fnf): Add Overburn indicator visuals

### DIFF
--- a/app/(app)/flames/components/FlameCard.tsx
+++ b/app/(app)/flames/components/FlameCard.tsx
@@ -51,6 +51,7 @@ export function FlameCard({
     elapsedSeconds,
     targetSeconds,
     progress,
+    isOverburning,
     toggle,
     isLoading,
     isSealReady,
@@ -141,7 +142,7 @@ export function FlameCard({
       case 'untended':
         return t('ready');
       case 'burning':
-        return t('burning');
+        return isOverburning ? t('overburning') : t('burning');
       case 'paused':
         return canSeal ? t('readyToSeal') : t('resting');
       case 'sealing':
@@ -165,10 +166,15 @@ export function FlameCard({
       };
 
   const borderGlowStyle = isActive
-    ? {
-        boxShadow: `0 0 15px ${colors.medium}50, 0 0 30px ${colors.medium}25`,
-        borderColor: colors.medium,
-      }
+    ? isOverburning
+      ? {
+          boxShadow: '0 0 15px #ef444450, 0 0 30px #ef444425',
+          borderColor: '#ef4444',
+        }
+      : {
+          boxShadow: `0 0 15px ${colors.medium}50, 0 0 30px ${colors.medium}25`,
+          borderColor: colors.medium,
+        }
     : canSeal || isSealing
       ? {
           boxShadow: '0 0 15px #fbbf2450, 0 0 30px #fbbf2425',
@@ -188,7 +194,7 @@ export function FlameCard({
       <div className="pointer-events-none absolute inset-0 z-10">
         <div className="relative h-full w-full">
           <div className="absolute left-0 right-0 top-8 h-28 sm:top-10 sm:h-40 md:h-52">
-            <EffectsRenderer effects={effects} state={state} colors={colors} />
+            <EffectsRenderer effects={effects} state={state} colors={colors} isOverburning={isOverburning} />
           </div>
         </div>
       </div>
@@ -246,6 +252,7 @@ export function FlameCard({
             level={level}
             colors={colors}
             sealProgress={isSealing ? longPress.progress : 0}
+            isOverburning={isOverburning}
           />
 
           {/* Seal ring progress overlay */}
@@ -261,20 +268,23 @@ export function FlameCard({
                 targetSeconds={targetSeconds}
                 state={state}
                 color={colors.light}
+                isOverburning={isOverburning}
               />
             </div>
           )}
           {flame.tracking_type === 'time' && targetSeconds > 0 && (
-            <ProgressBar progress={progress} state={state} colors={colors} />
+            <ProgressBar progress={progress} state={state} colors={colors} isOverburning={isOverburning} />
           )}
           <div
             className={cn(
               'text-center text-[10px] sm:text-xs',
               canSeal || isSealing
                 ? 'font-medium text-amber-500'
-                : isSealed
-                  ? 'font-medium'
-                  : 'text-slate-500 dark:text-white/50',
+                : isOverburning
+                  ? 'font-medium text-red-500'
+                  : isSealed
+                    ? 'font-medium'
+                    : 'text-slate-500 dark:text-white/50',
             )}
           >
             {isSealed ? (

--- a/app/(app)/flames/components/FuelMeter.tsx
+++ b/app/(app)/flames/components/FuelMeter.tsx
@@ -5,6 +5,7 @@ import { Fuel } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 import { useEffect, useRef, useState } from 'react';
 import { cn } from '@/lib/utils';
+import { SmokePuffs } from './SmokePuffs';
 
 interface FuelMeterProps {
   budgetSeconds: number | null;
@@ -45,116 +46,6 @@ const DROPLETS: {
     xDrift: -3,
     width: 2.5,
     height: 4.5,
-  },
-];
-
-/**
- * Smoke puffs — each is a soft blurred circle that drifts upward.
- * Multiple overlapping puffs at staggered timings create a smoky effect
- * through accumulation rather than any single shape looking like smoke.
- */
-const SMOKE_PUFFS: {
-  id: string;
-  size: number;
-  blur: number;
-  duration: number;
-  delay: number;
-  xPath: [number, number, number, number];
-  yEnd: number;
-  peakOpacity: number;
-}[] = [
-  // cluster 1 — drifts left
-  {
-    id: 'pf-0',
-    size: 5,
-    blur: 2,
-    duration: 2.0,
-    delay: 0,
-    xPath: [0, -2, -4, -6],
-    yEnd: -28,
-    peakOpacity: 0.4,
-  },
-  {
-    id: 'pf-1',
-    size: 3,
-    blur: 1.5,
-    duration: 1.8,
-    delay: 0.1,
-    xPath: [1, -1, -3, -4],
-    yEnd: -22,
-    peakOpacity: 0.3,
-  },
-  {
-    id: 'pf-2',
-    size: 4,
-    blur: 2.5,
-    duration: 2.2,
-    delay: 0.2,
-    xPath: [-1, -3, -2, -5],
-    yEnd: -32,
-    peakOpacity: 0.25,
-  },
-  // cluster 2 — drifts right
-  {
-    id: 'pf-3',
-    size: 4,
-    blur: 2,
-    duration: 2.2,
-    delay: 0.8,
-    xPath: [0, 3, 5, 4],
-    yEnd: -26,
-    peakOpacity: 0.35,
-  },
-  {
-    id: 'pf-4',
-    size: 6,
-    blur: 3,
-    duration: 2.4,
-    delay: 0.9,
-    xPath: [-1, 2, 4, 7],
-    yEnd: -30,
-    peakOpacity: 0.25,
-  },
-  {
-    id: 'pf-5',
-    size: 3,
-    blur: 1.5,
-    duration: 2.0,
-    delay: 1.0,
-    xPath: [1, 4, 3, 5],
-    yEnd: -20,
-    peakOpacity: 0.3,
-  },
-  // cluster 3 — center-ish
-  {
-    id: 'pf-6',
-    size: 5,
-    blur: 2.5,
-    duration: 2.6,
-    delay: 1.6,
-    xPath: [0, 1, -2, 0],
-    yEnd: -34,
-    peakOpacity: 0.3,
-  },
-  {
-    id: 'pf-7',
-    size: 3,
-    blur: 2,
-    duration: 2.0,
-    delay: 1.7,
-    xPath: [0, -2, 1, -1],
-    yEnd: -24,
-    peakOpacity: 0.35,
-  },
-  {
-    id: 'pf-8',
-    size: 4,
-    blur: 3,
-    duration: 2.4,
-    delay: 1.9,
-    xPath: [1, 0, -1, 2],
-    yEnd: -30,
-    peakOpacity: 0.2,
   },
 ];
 
@@ -410,35 +301,13 @@ export function FuelMeter({
                 ))}
 
                 {/* Smoke puffs — soft blurred circles that accumulate into smoke */}
-                {SMOKE_PUFFS.map((p) => (
-                  <motion.div
-                    key={p.id}
-                    className="absolute rounded-full"
-                    style={{
-                      width: p.size,
-                      height: p.size,
-                      left: -p.size / 2,
-                      top: '50%',
-                      filter: `blur(${p.blur}px)`,
-                      background: isLow
-                        ? 'rgba(252, 165, 165, 0.8)'
-                        : 'rgba(220, 180, 100, 0.7)',
-                    }}
-                    initial={{ opacity: 0, y: 0, x: 0, scale: 1 }}
-                    animate={{
-                      opacity: [0, p.peakOpacity, p.peakOpacity * 0.5, 0],
-                      y: [0, p.yEnd * 0.3, p.yEnd * 0.7, p.yEnd],
-                      x: p.xPath,
-                      scale: [0.6, 1, 1.4, 1.8],
-                    }}
-                    transition={{
-                      duration: p.duration,
-                      delay: p.delay,
-                      repeat: Number.POSITIVE_INFINITY,
-                      ease: 'easeOut',
-                    }}
-                  />
-                ))}
+                <SmokePuffs
+                  color={
+                    isLow
+                      ? 'rgba(252, 165, 165, 0.8)'
+                      : 'rgba(220, 180, 100, 0.7)'
+                  }
+                />
               </div>
             )}
           </div>

--- a/app/(app)/flames/components/SmokePuffs.tsx
+++ b/app/(app)/flames/components/SmokePuffs.tsx
@@ -1,0 +1,157 @@
+'use client';
+
+import { motion } from 'framer-motion';
+
+/**
+ * Smoke puffs — each is a soft blurred circle that drifts upward.
+ * Multiple overlapping puffs at staggered timings create a smoky effect
+ * through accumulation rather than any single shape looking like smoke.
+ */
+const SMOKE_PUFFS: {
+  id: string;
+  size: number;
+  blur: number;
+  duration: number;
+  delay: number;
+  xPath: [number, number, number, number];
+  yEnd: number;
+  peakOpacity: number;
+}[] = [
+  // cluster 1 — drifts left
+  {
+    id: 'pf-0',
+    size: 5,
+    blur: 2,
+    duration: 2.0,
+    delay: 0,
+    xPath: [0, -2, -4, -6],
+    yEnd: -28,
+    peakOpacity: 0.4,
+  },
+  {
+    id: 'pf-1',
+    size: 3,
+    blur: 1.5,
+    duration: 1.8,
+    delay: 0.1,
+    xPath: [1, -1, -3, -4],
+    yEnd: -22,
+    peakOpacity: 0.3,
+  },
+  {
+    id: 'pf-2',
+    size: 4,
+    blur: 2.5,
+    duration: 2.2,
+    delay: 0.2,
+    xPath: [-1, -3, -2, -5],
+    yEnd: -32,
+    peakOpacity: 0.25,
+  },
+  // cluster 2 — drifts right
+  {
+    id: 'pf-3',
+    size: 4,
+    blur: 2,
+    duration: 2.2,
+    delay: 0.8,
+    xPath: [0, 3, 5, 4],
+    yEnd: -26,
+    peakOpacity: 0.35,
+  },
+  {
+    id: 'pf-4',
+    size: 6,
+    blur: 3,
+    duration: 2.4,
+    delay: 0.9,
+    xPath: [-1, 2, 4, 7],
+    yEnd: -30,
+    peakOpacity: 0.25,
+  },
+  {
+    id: 'pf-5',
+    size: 3,
+    blur: 1.5,
+    duration: 2.0,
+    delay: 1.0,
+    xPath: [1, 4, 3, 5],
+    yEnd: -20,
+    peakOpacity: 0.3,
+  },
+  // cluster 3 — center-ish
+  {
+    id: 'pf-6',
+    size: 5,
+    blur: 2.5,
+    duration: 2.6,
+    delay: 1.6,
+    xPath: [0, 1, -2, 0],
+    yEnd: -34,
+    peakOpacity: 0.3,
+  },
+  {
+    id: 'pf-7',
+    size: 3,
+    blur: 2,
+    duration: 2.0,
+    delay: 1.7,
+    xPath: [0, -2, 1, -1],
+    yEnd: -24,
+    peakOpacity: 0.35,
+  },
+  {
+    id: 'pf-8',
+    size: 4,
+    blur: 3,
+    duration: 2.4,
+    delay: 1.9,
+    xPath: [1, 0, -1, 2],
+    yEnd: -30,
+    peakOpacity: 0.2,
+  },
+];
+
+interface SmokePuffsProps {
+  color: string;
+  /** Scale up size, opacity, and speed. Default 1. Higher = bigger, faster, more opaque. */
+  intensity?: number;
+}
+
+export function SmokePuffs({ color, intensity = 1 }: SmokePuffsProps) {
+  return (
+    <>
+      {SMOKE_PUFFS.map((p) => {
+        const size = p.size * intensity;
+        const peakOpacity = Math.min(p.peakOpacity * intensity, 1);
+        return (
+          <motion.div
+            key={p.id}
+            className="absolute rounded-full"
+            style={{
+              width: size,
+              height: size,
+              left: -size / 2,
+              top: '50%',
+              filter: `blur(${p.blur * intensity}px)`,
+              background: color,
+            }}
+            initial={{ opacity: 0, y: 0, x: 0, scale: 1 }}
+            animate={{
+              opacity: [0, peakOpacity, peakOpacity * 0.5, 0],
+              y: [0, p.yEnd * 0.3, p.yEnd * 0.7, p.yEnd],
+              x: p.xPath,
+              scale: [0.6, 1, 1.4, 1.8],
+            }}
+            transition={{
+              duration: p.duration / intensity,
+              delay: p.delay / intensity,
+              repeat: Number.POSITIVE_INFINITY,
+              ease: 'easeOut',
+            }}
+          />
+        );
+      })}
+    </>
+  );
+}

--- a/app/(app)/flames/components/flame-card/ProgressBar.tsx
+++ b/app/(app)/flames/components/flame-card/ProgressBar.tsx
@@ -2,6 +2,7 @@
 
 import { motion, useReducedMotion } from 'framer-motion';
 import type { FlameState } from '../../utils/types';
+import { SmokePuffs } from '../SmokePuffs';
 
 interface ProgressBarProps {
   progress: number;
@@ -11,31 +12,50 @@ interface ProgressBarProps {
     medium: string;
     dark: string;
   };
+  isOverburning?: boolean;
 }
 
 const SEALED_BAR_GRADIENT =
   'linear-gradient(to right, #92400e, #d97706, #f59e0b, #fbbf24)';
 
-export function ProgressBar({ progress, state, colors }: ProgressBarProps) {
+const OVERBURN_BAR_GRADIENT =
+  'linear-gradient(to right, #dc2626, #ef4444, #f87171)';
+
+export function ProgressBar({
+  progress,
+  state,
+  colors,
+  isOverburning = false,
+}: ProgressBarProps) {
   const shouldReduceMotion = useReducedMotion();
   const isActive = state === 'burning';
   const isSealed = state === 'sealed';
 
   const percentage = isSealed ? 100 : Math.round(progress * 100);
 
+  const barBackground = isSealed
+    ? SEALED_BAR_GRADIENT
+    : isOverburning
+      ? OVERBURN_BAR_GRADIENT
+      : `linear-gradient(to right, ${colors.dark}, ${colors.medium}, ${colors.light})`;
+
+  const barShadow = isActive
+    ? isOverburning
+      ? '0 0 8px #ef4444, 0 0 16px #ef444440'
+      : `0 0 8px ${colors.medium}, 0 0 16px ${colors.medium}40`
+    : isSealed
+      ? '0 0 6px #d9770640'
+      : 'none';
+
   return (
-    <div className="relative h-1.5 w-full overflow-hidden rounded-full bg-slate-200 dark:bg-white/10 sm:h-2">
+    <div
+      className={`relative h-1.5 w-full rounded-full bg-slate-200 dark:bg-white/10 sm:h-2 ${isOverburning ? 'overflow-visible' : 'overflow-hidden'}`}
+    >
       <motion.div
         className="absolute inset-y-0 left-0 rounded-full"
         style={{
-          background: isSealed
-            ? SEALED_BAR_GRADIENT
-            : `linear-gradient(to right, ${colors.dark}, ${colors.medium}, ${colors.light})`,
-          boxShadow: isActive
-            ? `0 0 8px ${colors.medium}, 0 0 16px ${colors.medium}40`
-            : isSealed
-              ? '0 0 6px #d9770640'
-              : 'none',
+          background: barBackground,
+          boxShadow: barShadow,
         }}
         initial={false}
         animate={{
@@ -56,7 +76,9 @@ export function ProgressBar({ progress, state, colors }: ProgressBarProps) {
           className="absolute inset-y-0 left-0 rounded-full"
           style={{
             width: `${percentage}%`,
-            background: `linear-gradient(to right, transparent, ${colors.light}40)`,
+            background: isOverburning
+              ? 'linear-gradient(to right, transparent, #f8717140)'
+              : `linear-gradient(to right, transparent, ${colors.light}40)`,
           }}
           animate={{
             opacity: [0.5, 1, 0.5],
@@ -67,6 +89,14 @@ export function ProgressBar({ progress, state, colors }: ProgressBarProps) {
             ease: 'easeInOut',
           }}
         />
+      )}
+      {isOverburning && !shouldReduceMotion && (
+        <div
+          className="pointer-events-none absolute top-0 h-full"
+          style={{ left: '100%' }}
+        >
+          <SmokePuffs color="rgba(120, 113, 108, 0.85)" intensity={1.8} />
+        </div>
       )}
     </div>
   );

--- a/app/(app)/flames/components/flame-card/TimerDisplay.tsx
+++ b/app/(app)/flames/components/flame-card/TimerDisplay.tsx
@@ -8,6 +8,7 @@ interface TimerDisplayProps {
   targetSeconds: number;
   state: FlameState;
   color: string;
+  isOverburning?: boolean;
 }
 
 function formatTimeCompact(totalSeconds: number): string {
@@ -26,6 +27,7 @@ export function TimerDisplay({
   targetSeconds,
   state,
   color,
+  isOverburning = false,
 }: TimerDisplayProps) {
   const shouldReduceMotion = useReducedMotion();
   const isActive = state === 'burning';
@@ -54,7 +56,9 @@ export function TimerDisplay({
   const textColorClass =
     state === 'sealed'
       ? '' // Use inline color prop for completed state
-      : 'text-slate-700 dark:text-white/80';
+      : isOverburning
+        ? 'text-red-500 dark:text-red-400'
+        : 'text-slate-700 dark:text-white/80';
 
   return (
     <motion.div

--- a/app/(app)/flames/components/flame-card/effects/EffectsRenderer.tsx
+++ b/app/(app)/flames/components/flame-card/effects/EffectsRenderer.tsx
@@ -10,12 +10,14 @@ interface EffectsRendererProps {
   effects: EffectConfig[];
   state: FlameState;
   colors: ShapeColors;
+  isOverburning?: boolean;
 }
 
 export function EffectsRenderer({
   effects,
   state,
   colors,
+  isOverburning = false,
 }: EffectsRendererProps) {
   return (
     <>
@@ -37,6 +39,7 @@ export function EffectsRenderer({
                 state={state}
                 colors={colors}
                 config={effect}
+                isOverburning={isOverburning}
               />
             );
           case 'sealedSmoke':

--- a/app/(app)/flames/components/flame-card/effects/FlameRenderer.tsx
+++ b/app/(app)/flames/components/flame-card/effects/FlameRenderer.tsx
@@ -35,6 +35,7 @@ interface FlameRendererProps {
   colors: ShapeColors;
   sealProgress?: number;
   className?: string;
+  isOverburning?: boolean;
 }
 
 export function FlameRenderer({
@@ -43,6 +44,7 @@ export function FlameRenderer({
   colors,
   sealProgress = 0,
   className,
+  isOverburning = false,
 }: FlameRendererProps) {
   const shouldReduceMotion = useReducedMotion();
   const clampedLevel = Math.max(1, Math.min(8, level));
@@ -101,12 +103,15 @@ export function FlameRenderer({
   const isSealing = state === 'sealing';
   const svgAnimate = isSealing
     ? { scale: 0.8 + sealProgress * 0.35, y: sealProgress * -6, opacity: 1 }
-    : stateVariants[state];
+    : isOverburning
+      ? { scale: 1.25, opacity: 1, y: -6 }
+      : stateVariants[state];
   const svgTransition = isSealing
     ? { type: 'tween' as const, duration: 0.1, ease: 'linear' as const }
     : springTransition;
 
-  const animDuration = animation.durations[state];
+  const animDuration =
+    animation.durations[state] * (isOverburning ? 0.55 : 1);
   const animTransition = {
     duration: animDuration,
     repeat: Infinity,

--- a/app/(app)/flames/components/hooks/useFlameState.ts
+++ b/app/(app)/flames/components/hooks/useFlameState.ts
@@ -18,6 +18,7 @@ interface UseFlameTimerReturn {
   elapsedSeconds: number;
   targetSeconds: number;
   progress: number;
+  isOverburning: boolean;
   toggle: () => Promise<void>;
   isLoading: boolean;
   isSealReady: boolean;
@@ -84,9 +85,6 @@ export function useFlameState({
         setLocalElapsed((prev) => {
           const newElapsed = prev + 1;
           // Indicates overburn (going above budgeted time)
-          if (targetSeconds > 0 && newElapsed >= targetSeconds) {
-            // TODO: Add overburn warning state handling here
-          }
           return newElapsed;
         });
       }, 1000);
@@ -180,11 +178,15 @@ export function useFlameState({
   const progress =
     targetSeconds > 0 ? Math.min(localElapsed / targetSeconds, 1) : 0;
 
+  const isOverburning =
+    state === 'burning' && targetSeconds > 0 && localElapsed > targetSeconds;
+
   return {
     state,
     elapsedSeconds: localElapsed,
     targetSeconds,
     progress,
+    isOverburning,
     toggle,
     isLoading,
     isSealReady,

--- a/messages/en.json
+++ b/messages/en.json
@@ -104,7 +104,8 @@
       "noFuel": "No fuel",
       "sealing": "Sealing ...",
       "sealed": "Sealed",
-      "readyToSeal": "Ready to Seal"
+      "readyToSeal": "Ready to Seal",
+      "overburning": "Overburn"
     },
     "seal": {
       "title": "Flame Sealed!",

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -104,7 +104,8 @@
       "noFuel": "No fuel",
       "sealing": "封印中 ...",
       "sealed": "封印済み",
-      "readyToSeal": "封印可能"
+      "readyToSeal": "封印可能",
+      "overburning": "超過燃焼"
     },
     "seal": {
       "title": "炎を封印しました！",


### PR DESCRIPTION
## Overview
When users are burning more fuel than they have budgeted for a flame, it enters Overburn mode. Spending more time than you allocated to a specific task isn't good because it means you may not have enough Fuel for the day to tend to other flames, so this visually indicates this to the user.

### Visual Effects
- Black smoke puffs coming from the tip of the progress bar
- Intensified flame burn animation and particle effects (faster flickering and more black smoke particles)
- Label changes to "Overburn"

<img width="494" height="571" alt="image" src="https://github.com/user-attachments/assets/0429fd27-ca1c-4345-bd9f-ca4d80c94480" />
