### PR TITLE
feat(fnf): Schedule View: Allow editing flame budgets inline

### DIFF
--- a/app/(app)/schedule/components/DayRowFuelBar.tsx
+++ b/app/(app)/schedule/components/DayRowFuelBar.tsx
@@ -17,14 +17,19 @@ const WARM_COLORS = new Set<string>([
 interface DayRowFuelBarProps {
   fuelMinutes: number;
   assignedFlames: FlameWithSchedule[];
+  allocations?: Record<string, number>;
 }
 
 export function DayRowFuelBar({
   fuelMinutes,
   assignedFlames,
+  allocations,
 }: DayRowFuelBarProps) {
+  const getAllocation = (flame: FlameWithSchedule) =>
+    allocations?.[flame.id] ?? flame.time_budget_minutes ?? 0;
+
   const allocatedMinutes = assignedFlames.reduce(
-    (sum, f) => sum + (f.time_budget_minutes ?? 0),
+    (sum, f) => sum + getAllocation(f),
     0,
   );
   const isOverCapacity = fuelMinutes > 0 && allocatedMinutes > fuelMinutes;
@@ -43,7 +48,7 @@ export function DayRowFuelBar({
     const result: Segment[] = [];
 
     for (const flame of assignedFlames) {
-      const budget = flame.time_budget_minutes ?? 0;
+      const budget = getAllocation(flame);
       if (budget <= 0) continue;
 
       const startPct = (cursor / fuelMinutes) * 100;
@@ -60,7 +65,8 @@ export function DayRowFuelBar({
     }
 
     return result;
-  }, [fuelMinutes, assignedFlames]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [fuelMinutes, assignedFlames, allocations]);
 
   // Overflow segment for over-capacity
   const overflowPct =

--- a/app/(app)/schedule/components/dialog/AssignedFlamesZone.tsx
+++ b/app/(app)/schedule/components/dialog/AssignedFlamesZone.tsx
@@ -11,11 +11,15 @@ import { DraggableFlame } from './DraggableFlame';
 interface AssignedFlamesZoneProps {
   flames: FlameWithSchedule[];
   onRemove: (flameId: string) => void;
+  allocations: Record<string, number>;
+  onAllocationChange: (flameId: string, minutes: number) => void;
 }
 
 export function AssignedFlamesZone({
   flames,
   onRemove,
+  allocations,
+  onAllocationChange,
 }: AssignedFlamesZoneProps) {
   // Map flame id → level based on index in the full flames array
   // This is only for testing purposes and must be replaced by actual levels once the data model for flames is updated
@@ -51,6 +55,8 @@ export function AssignedFlamesZone({
               disabled={flame.is_daily}
               showDaily={flame.is_daily}
               onClick={flame.is_daily ? undefined : () => onRemove(flame.id)}
+              allocatedMinutes={allocations[flame.id]}
+              onAllocationChange={(mins) => onAllocationChange(flame.id, mins)}
             />
           ))}
         </div>

--- a/app/(app)/schedule/components/dialog/DraggableFlame.tsx
+++ b/app/(app)/schedule/components/dialog/DraggableFlame.tsx
@@ -1,7 +1,9 @@
 'use client';
 
 import { useDraggable } from '@dnd-kit/core';
+import { Pencil } from 'lucide-react';
 import { useTranslations } from 'next-intl';
+import { useRef, useState } from 'react';
 import { FlameRenderer } from '@/app/(app)/flames/components/flame-card/effects/FlameRenderer';
 import type { FlameColorName } from '@/app/(app)/flames/utils/colors';
 import { getFlameColors } from '@/app/(app)/flames/utils/colors';
@@ -14,7 +16,11 @@ interface DraggableFlameProps {
   disabled?: boolean;
   showDaily?: boolean;
   onClick?: () => void;
+  allocatedMinutes?: number;
+  onAllocationChange?: (minutes: number) => void;
 }
+
+const MIN_ALLOCATION = 15;
 
 export function DraggableFlame({
   flame,
@@ -22,6 +28,8 @@ export function DraggableFlame({
   disabled = false,
   showDaily = false,
   onClick,
+  allocatedMinutes,
+  onAllocationChange,
 }: DraggableFlameProps) {
   const t = useTranslations('schedule');
   const { attributes, listeners, setNodeRef, transform, isDragging } =
@@ -31,7 +39,17 @@ export function DraggableFlame({
       data: { flame },
     });
 
+  const [isEditingTime, setIsEditingTime] = useState(false);
+  const [editValue, setEditValue] = useState('');
+  const inputRef = useRef<HTMLInputElement>(null);
+
   const colors = getFlameColors(flame.color as FlameColorName);
+
+  const displayMinutes = allocatedMinutes ?? flame.time_budget_minutes;
+  const isCustomAllocation =
+    allocatedMinutes != null &&
+    flame.time_budget_minutes != null &&
+    allocatedMinutes !== flame.time_budget_minutes;
 
   const formatMinutes = (mins: number) => {
     const h = Math.floor(mins / 60);
@@ -39,6 +57,25 @@ export function DraggableFlame({
     if (h > 0 && m > 0) return `${h}${t('hours')} ${m}${t('minutes')}`;
     if (h > 0) return `${h}${t('hours')}`;
     return `${m}${t('minutes')}`;
+  };
+
+  const handleTimeClick = (e: React.MouseEvent) => {
+    if (!onAllocationChange || !allocatedMinutes) return;
+    e.stopPropagation();
+    e.preventDefault();
+    setEditValue(String(allocatedMinutes));
+    setIsEditingTime(true);
+    requestAnimationFrame(() => inputRef.current?.select());
+  };
+
+  const commitTimeEdit = () => {
+    const parsed = Number.parseInt(editValue, 10);
+    if (!Number.isNaN(parsed) && parsed >= MIN_ALLOCATION && onAllocationChange) {
+      // Snap to 15-min increments
+      const snapped = Math.round(parsed / 15) * 15;
+      onAllocationChange(Math.max(snapped, MIN_ALLOCATION));
+    }
+    setIsEditingTime(false);
   };
 
   const style: React.CSSProperties = {
@@ -81,10 +118,44 @@ export function DraggableFlame({
         {flame.name}
       </span>
       <div className="flex items-center gap-1">
-        {flame.time_budget_minutes != null && (
-          <span className="text-xs text-muted-foreground">
-            {formatMinutes(flame.time_budget_minutes)}
-          </span>
+        {displayMinutes != null && (
+          isEditingTime ? (
+            <input
+              ref={inputRef}
+              type="number"
+              min={MIN_ALLOCATION}
+              step={15}
+              className="w-12 border-b border-amber-400 bg-transparent text-center text-xs tabular-nums outline-none"
+              value={editValue}
+              onChange={(e) => setEditValue(e.target.value)}
+              onBlur={commitTimeEdit}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') commitTimeEdit();
+                if (e.key === 'Escape') setIsEditingTime(false);
+              }}
+              onClick={(e) => e.stopPropagation()}
+              onPointerDown={(e) => e.stopPropagation()}
+              // biome-ignore lint/a11y/noAutofocus: Editing mode
+              autoFocus
+            />
+          ) : (
+            <span
+              className={cn(
+                'text-xs',
+                isCustomAllocation
+                  ? 'font-medium text-amber-600 dark:text-amber-400'
+                  : 'text-muted-foreground',
+                onAllocationChange && 'cursor-pointer hover:underline',
+              )}
+              onClick={handleTimeClick}
+              onPointerDown={onAllocationChange ? (e) => e.stopPropagation() : undefined}
+            >
+              {formatMinutes(displayMinutes)}
+              {isCustomAllocation && (
+                <Pencil className="ml-0.5 inline size-2.5" />
+              )}
+            </span>
+          )
         )}
         {showDaily && (
           <span className="rounded bg-amber-500/10 px-1 py-0.5 text-[10px] font-medium text-amber-600">

--- a/supabase/migrations/20260215000000_add_flame_minutes.sql
+++ b/supabase/migrations/20260215000000_add_flame_minutes.sql
@@ -1,0 +1,3 @@
+-- Add per-flame time allocations as a parallel array to flame_ids
+ALTER TABLE public.weekly_schedule_overrides
+  ADD COLUMN flame_minutes integer[] NOT NULL DEFAULT '{}';

--- a/utils/supabase/types.ts
+++ b/utils/supabase/types.ts
@@ -332,6 +332,7 @@ export type Database = {
         Row: {
           day_of_week: number
           flame_ids: string[]
+          flame_minutes: number[]
           minutes: number
           user_id: string
           week_start: string
@@ -339,6 +340,7 @@ export type Database = {
         Insert: {
           day_of_week: number
           flame_ids?: string[]
+          flame_minutes?: number[]
           minutes: number
           user_id: string
           week_start: string
@@ -346,6 +348,7 @@ export type Database = {
         Update: {
           day_of_week?: number
           flame_ids?: string[]
+          flame_minutes?: number[]
           minutes?: number
           user_id?: string
           week_start?: string


### PR DESCRIPTION
## Overview
Updates the Weekly Planner / Schedule view to allow editing the amount of fuel allocated per flame. Flames use default allocation, but you can now adjust per day when planning, in case you want to budget more time for specific tasks than normal (i.e. this week I want to budget more time to interview prep due to upcoming interviews)

Includes editing via click to edit time labels, and also adjustable handles for each segment in the fuel bar


<img width="1781" height="760" alt="image" src="https://github.com/user-attachments/assets/753bd300-b298-4a70-98ce-5de2ccd3c16b" />
