### PR TITLE
ref: Theme refinement — warm light mode + token migration

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,6 +56,13 @@ messages/         # i18n translation files (en.json, ja.json)
 - **Types**: colocated or in `types.ts`. Suffix `Props` for component props, `Schema` for Zod, `Result` for action returns
 - **Translations**: Always use `useTranslations()` from next-intl. All user-facing strings go in `messages/en.json` and `messages/ja.json`.
 - **Formatting**: Run `pnpm biome check --write` before committing. Single quotes, 2-space indent.
+- **Theme Colors**: Use CSS theme tokens from `globals.css` instead of hard-coded Tailwind color classes. The theme system handles light/dark mode automatically.
+  - Backgrounds: `bg-background`, `bg-card`, `bg-muted` — NOT `bg-white`, `bg-slate-50`, `bg-slate-200`
+  - Text: `text-foreground`, `text-muted-foreground`, `text-card-foreground` — NOT `text-slate-900`, `text-slate-500`, `text-gray-400`
+  - Borders: `border-border` — NOT `border-slate-200`
+  - SVG fills: `fill-muted` — NOT `fill-slate-200`
+  - Do NOT add `dark:` overrides for colors that the theme already handles (e.g. `dark:text-white` alongside `text-foreground` is redundant)
+  - Flame-specific status colors (`text-amber-500`, `text-red-500`, gradient hex values) are intentionally NOT theme tokens — keep those as-is
 
 ## Git Conventions
 

--- a/app/(app)/components/BottomNav.tsx
+++ b/app/(app)/components/BottomNav.tsx
@@ -32,7 +32,9 @@ export function BottomNav() {
               key={item.href}
               href={item.href}
               className={`flex flex-col items-center justify-center gap-0.5 transition-all duration-200 ${
-                isActive ? 'text-primary' : 'text-gray-400 active:scale-95'
+                isActive
+                  ? 'text-primary'
+                  : 'text-muted-foreground active:scale-95'
               }`}
             >
               <span className="text-xl leading-none">{item.icon}</span>

--- a/app/(app)/flames/components/FlameCard.tsx
+++ b/app/(app)/flames/components/FlameCard.tsx
@@ -217,8 +217,7 @@ export function FlameCard({
         aria-label={getAriaLabel()}
         className={cn(
           'relative flex w-full flex-col overflow-hidden rounded-xl border transition-colors',
-          'border-slate-200 bg-linear-to-b from-white to-slate-50 text-slate-900',
-          'dark:border-white/10 dark:from-slate-900 dark:to-slate-950 dark:text-white',
+          'border-border bg-card text-foreground',
           'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 cursor-pointer',
           isSealed && 'cursor-default',
           isFuelBlocked && 'cursor-default opacity-40',
@@ -265,7 +264,7 @@ export function FlameCard({
         </div>
 
         {/* Footer - Timer, Progress, State */}
-        <div className="flex flex-col gap-1 bg-slate-200/70 px-2 py-2 dark:bg-black/30 sm:gap-1.5 sm:px-3 sm:py-3">
+        <div className="flex flex-col gap-1 bg-muted px-2 py-2 sm:gap-1.5 sm:px-3 sm:py-3">
           {flame.tracking_type === 'time' && targetSeconds > 0 && (
             <div className={cn(isSealed && 'opacity-40')}>
               <TimerDisplay
@@ -294,7 +293,7 @@ export function FlameCard({
                   ? 'font-medium text-red-500'
                   : isSealed
                     ? 'font-medium'
-                    : 'text-slate-500 dark:text-white/50',
+                    : 'text-muted-foreground',
             )}
           >
             {isSealed ? (

--- a/app/(app)/flames/components/FlameCardSkeleton.tsx
+++ b/app/(app)/flames/components/FlameCardSkeleton.tsx
@@ -2,18 +2,18 @@ import { Fuel } from 'lucide-react';
 
 export function FlameCardSkeleton() {
   return (
-    <div className="relative flex w-full flex-col overflow-hidden rounded-xl border border-slate-200 bg-linear-to-b from-white to-slate-50 dark:border-white/10 dark:from-slate-900 dark:to-slate-950">
+    <div className="relative flex w-full flex-col overflow-hidden rounded-xl border border-border bg-card">
       {/* Header - Name and Level placeholders */}
       <div className="flex flex-col items-center gap-1 px-2 pt-2 sm:px-3 sm:pt-3">
-        <div className="h-3.5 w-3/5 animate-pulse rounded-md bg-slate-200 dark:bg-white/10 sm:h-4 md:h-5" />
-        <div className="h-2.5 w-2/5 animate-pulse rounded-md bg-slate-200/70 dark:bg-white/[0.06] sm:h-3" />
+        <div className="h-3.5 w-3/5 animate-pulse rounded-md bg-muted sm:h-4 md:h-5" />
+        <div className="h-2.5 w-2/5 animate-pulse rounded-md bg-muted/50 sm:h-3" />
       </div>
 
       {/* Flame visual area - organic pulsing shape */}
       <div className="relative flex h-28 items-center justify-center sm:h-40 md:h-52">
         <div className="relative flex items-center justify-center">
           {/* Soft glow behind the shape */}
-          <div className="absolute h-16 w-14 animate-pulse rounded-full bg-slate-200/50 blur-lg dark:bg-white/[0.04] sm:h-24 sm:w-20 md:h-32 md:w-28" />
+          <div className="absolute h-16 w-14 animate-pulse rounded-full bg-muted/50 blur-lg sm:h-24 sm:w-20 md:h-32 md:w-28" />
           {/* Flame-shaped skeleton */}
           <svg
             viewBox="0 0 60 80"
@@ -22,11 +22,11 @@ export function FlameCardSkeleton() {
           >
             <path
               d="M30 4 C18 20, 6 35, 6 52 C6 66, 16 76, 30 76 C44 76, 54 66, 54 52 C54 35, 42 20, 30 4Z"
-              className="animate-pulse fill-slate-200 dark:fill-white/10"
+              className="animate-pulse fill-muted"
             />
             <path
               d="M30 24 C24 34, 16 42, 16 52 C16 60, 22 66, 30 66 C38 66, 44 60, 44 52 C44 42, 36 34, 30 24Z"
-              className="animate-pulse fill-slate-100 dark:fill-white/[0.06]"
+              className="animate-pulse fill-muted/50"
               style={{ animationDelay: '150ms' }}
             />
           </svg>
@@ -34,16 +34,16 @@ export function FlameCardSkeleton() {
       </div>
 
       {/* Footer - Timer, Progress, State placeholders */}
-      <div className="flex flex-col gap-1 bg-slate-200/70 px-2 py-2 dark:bg-black/30 sm:gap-1.5 sm:px-3 sm:py-3">
+      <div className="flex flex-col gap-1 bg-muted px-2 py-2 sm:gap-1.5 sm:px-3 sm:py-3">
         {/* Timer placeholder */}
         <div className="flex justify-center">
-          <div className="h-3 w-16 animate-pulse rounded bg-slate-300/60 dark:bg-white/10 sm:h-3.5 sm:w-20" />
+          <div className="h-3 w-16 animate-pulse rounded bg-muted-foreground/20 sm:h-3.5 sm:w-20" />
         </div>
         {/* Progress bar placeholder */}
-        <div className="h-1.5 w-full animate-pulse rounded-full bg-slate-300/50 dark:bg-white/10 sm:h-2" />
+        <div className="h-1.5 w-full animate-pulse rounded-full bg-muted-foreground/20 sm:h-2" />
         {/* State text placeholder */}
         <div className="flex justify-center">
-          <div className="h-2.5 w-10 animate-pulse rounded bg-slate-300/40 dark:bg-white/[0.06] sm:h-3 sm:w-12" />
+          <div className="h-2.5 w-10 animate-pulse rounded bg-muted-foreground/15 sm:h-3 sm:w-12" />
         </div>
       </div>
     </div>
@@ -52,8 +52,8 @@ export function FlameCardSkeleton() {
 
 export function FuelMeterSkeleton({ label }: { label: string }) {
   return (
-    <div className="sticky top-0 z-20 -mx-4 mb-4 bg-white/80 px-4 pt-4 pb-0 backdrop-blur-sm dark:bg-slate-950/80">
-      <div className="rounded-lg border border-slate-200 bg-slate-50 px-3 py-2.5 dark:border-white/10 dark:bg-white/5">
+    <div className="sticky top-0 z-20 -mx-4 mb-4 bg-background/80 px-4 pt-4 pb-0 backdrop-blur-sm">
+      <div className="rounded-lg border border-border bg-card px-3 py-2.5">
         <div className="flex items-center gap-2.5">
           {/* Icon + label — static, no skeleton needed */}
           <div className="flex shrink-0 items-center gap-1 text-amber-600 dark:text-amber-400">
@@ -63,9 +63,9 @@ export function FuelMeterSkeleton({ label }: { label: string }) {
             </span>
           </div>
           {/* Bar placeholder */}
-          <div className="h-3 flex-1 animate-pulse rounded-full bg-slate-200 dark:bg-white/10" />
+          <div className="h-3 flex-1 animate-pulse rounded-full bg-muted" />
           {/* Time label placeholder */}
-          <div className="h-3 w-14 shrink-0 animate-pulse rounded bg-slate-300/60 dark:bg-white/10" />
+          <div className="h-3 w-14 shrink-0 animate-pulse rounded bg-muted" />
         </div>
       </div>
     </div>

--- a/app/(app)/flames/components/FuelMeter.tsx
+++ b/app/(app)/flames/components/FuelMeter.tsx
@@ -73,9 +73,9 @@ export function FuelMeter({
 
   if (!hasBudget) {
     return (
-      <div className="sticky top-0 z-20 -mx-4 mb-4 bg-white/80 px-4 pt-4 pb-0 backdrop-blur-sm dark:bg-slate-950/80">
-        <div className="rounded-lg border border-slate-200 bg-slate-50 px-3 py-2 dark:border-white/10 dark:bg-white/5">
-          <p className="text-center text-xs text-slate-500 dark:text-white/50">
+      <div className="sticky top-0 z-20 -mx-4 mb-4 bg-background/80 px-4 pt-4 pb-0 backdrop-blur-sm">
+        <div className="rounded-lg border border-border bg-card px-3 py-2">
+          <p className="text-center text-xs text-muted-foreground">
             {t('noBudget')}
           </p>
         </div>
@@ -90,19 +90,19 @@ export function FuelMeter({
 
   // Bar color logic: normal → amber, low → shifts to orange/red, depleted → grey
   const barColor = isDepleted
-    ? 'bg-slate-400 dark:bg-white/20'
+    ? 'bg-muted-foreground/40'
     : isLow
       ? 'bg-gradient-to-r from-red-500 to-orange-400 dark:from-red-500 dark:to-orange-400'
       : 'bg-gradient-to-r from-amber-500 to-amber-400 dark:from-amber-500 dark:to-amber-400';
 
   const textColor = isDepleted
-    ? 'text-slate-400 dark:text-white/30'
+    ? 'text-muted-foreground/60'
     : isLow
       ? 'text-red-600 dark:text-red-400'
-      : 'text-slate-600 dark:text-white/70';
+      : 'text-muted-foreground';
 
   const iconColor = isDepleted
-    ? 'text-slate-400 dark:text-white/30'
+    ? 'text-muted-foreground/60'
     : isLow
       ? 'text-red-500 dark:text-red-400'
       : 'text-amber-600 dark:text-amber-400';
@@ -116,9 +116,9 @@ export function FuelMeter({
     : 'rgba(245, 158, 11, 0.25)';
 
   return (
-    <div className="sticky top-0 z-20 -mx-4 mb-4 bg-white/80 px-4 pt-4 pb-0 backdrop-blur-sm dark:bg-slate-950/80">
+    <div className="sticky top-0 z-20 -mx-4 mb-4 bg-background/80 px-4 pt-4 pb-0 backdrop-blur-sm">
       <motion.div
-        className="rounded-lg border border-slate-200 bg-slate-50 px-3 py-2.5 dark:border-white/10 dark:bg-white/5"
+        className="rounded-lg border border-border bg-card px-3 py-2.5"
         initial={false}
         animate={
           isBurning && !isDepleted && !shouldReduceMotion
@@ -152,7 +152,7 @@ export function FuelMeter({
 
           {/* Bar container */}
           <div className="relative h-3 flex-1 overflow-visible">
-            <div className="relative h-full overflow-hidden rounded-full bg-slate-200 dark:bg-white/10">
+            <div className="relative h-full overflow-hidden rounded-full bg-muted">
               {/* Segment ticks — repeating gradient overlay, auto-adapts to width */}
               <div
                 className="pointer-events-none absolute inset-0 z-10 rounded-full opacity-20 dark:opacity-15"

--- a/app/(app)/flames/components/SealSummaryModal.tsx
+++ b/app/(app)/flames/components/SealSummaryModal.tsx
@@ -165,7 +165,7 @@ function SealFuelMeter({
         </div>
 
         {/* Bar */}
-        <div className="relative h-3 flex-1 overflow-hidden rounded-full bg-white/10">
+        <div className="relative h-3 flex-1 overflow-hidden rounded-full bg-muted">
           {/* Segment ticks — matching real FuelMeter */}
           <div
             className="pointer-events-none absolute inset-0 z-10 rounded-full"
@@ -203,7 +203,7 @@ function SealFuelMeter({
         </div>
 
         {/* Time label */}
-        <span className="shrink-0 text-xs font-medium tabular-nums text-white/50">
+        <span className="shrink-0 text-xs font-medium tabular-nums text-muted-foreground">
           {formatTime(elapsedSeconds)} / {formatTime(targetSeconds)}
         </span>
       </div>
@@ -300,7 +300,7 @@ export function SealSummaryModal({
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent
         showCloseButton={false}
-        className="overflow-visible border bg-slate-950 text-white"
+        className="overflow-visible border bg-card text-card-foreground"
         style={{
           borderColor: `${colors.medium}40`,
           boxShadow: `0 0 30px ${colors.medium}20, 0 0 60px ${colors.medium}10`,
@@ -330,7 +330,7 @@ export function SealSummaryModal({
             >
               {flameName} {t('title')}
             </h2>
-            <p className="mt-1 text-sm text-white/50">{subtitle}</p>
+            <p className="mt-1 text-sm text-muted-foreground">{subtitle}</p>
           </motion.div>
 
           {/* Hero flame visual — center of dialog */}
@@ -400,7 +400,9 @@ export function SealSummaryModal({
                   +{sparksCount}
                 </span>
               </div>
-              <span className="text-xs text-white/50">{t('sparksEarned')}</span>
+              <span className="text-xs text-muted-foreground">
+                {t('sparksEarned')}
+              </span>
             </motion.div>
 
             <motion.div
@@ -419,7 +421,9 @@ export function SealSummaryModal({
                   +{xpCount}
                 </span>
               </div>
-              <span className="text-xs text-white/50">{t('xpEarned')}</span>
+              <span className="text-xs text-muted-foreground">
+                {t('xpEarned')}
+              </span>
             </motion.div>
           </div>
         </div>

--- a/app/(app)/flames/components/flame-card/ProgressBar.tsx
+++ b/app/(app)/flames/components/flame-card/ProgressBar.tsx
@@ -49,7 +49,7 @@ export function ProgressBar({
 
   return (
     <div
-      className={`relative h-1.5 w-full rounded-full bg-slate-200 dark:bg-white/10 sm:h-2 ${isOverburning ? 'overflow-visible' : 'overflow-hidden'}`}
+      className={`relative h-1.5 w-full rounded-full bg-muted sm:h-2 ${isOverburning ? 'overflow-visible' : 'overflow-hidden'}`}
     >
       <motion.div
         className="absolute inset-y-0 left-0 rounded-full"

--- a/app/(app)/flames/components/flame-card/TimerDisplay.tsx
+++ b/app/(app)/flames/components/flame-card/TimerDisplay.tsx
@@ -58,7 +58,7 @@ export function TimerDisplay({
       ? '' // Use inline color prop for completed state
       : isOverburning
         ? 'text-red-500 dark:text-red-400'
-        : 'text-slate-700 dark:text-white/80';
+        : 'text-foreground';
 
   return (
     <motion.div

--- a/app/(app)/flames/loading.tsx
+++ b/app/(app)/flames/loading.tsx
@@ -10,7 +10,7 @@ export default async function FlamesLoading() {
   return (
     <div className="size-full p-4 pb-24">
       {/* Page title skeleton */}
-      <div className="mb-6 h-8 w-32 animate-pulse rounded-lg bg-slate-200 dark:bg-white/10" />
+      <div className="mb-6 h-8 w-32 animate-pulse rounded-lg bg-muted" />
 
       <FuelMeterSkeleton label={t('fuel.label')} />
 

--- a/app/(app)/flames/schedule/components/DayRowFuelBar.tsx
+++ b/app/(app)/flames/schedule/components/DayRowFuelBar.tsx
@@ -74,7 +74,7 @@ export function DayRowFuelBar({
     : 0;
 
   return (
-    <div className="relative h-2.5 w-full overflow-hidden rounded-full bg-slate-200 dark:bg-white/10">
+    <div className="relative h-2.5 w-full overflow-hidden rounded-full bg-muted">
       {segments.map((seg) => (
         <div
           key={`seg-${seg.startPct}`}

--- a/app/(app)/flames/schedule/components/MiniFlameCard.tsx
+++ b/app/(app)/flames/schedule/components/MiniFlameCard.tsx
@@ -25,8 +25,7 @@ export function MiniFlameCard({
     <div
       className={cn(
         'flex w-28 shrink-0 flex-col overflow-hidden rounded-xl border sm:w-36',
-        'border-slate-200 bg-linear-to-b from-white to-slate-50',
-        'dark:border-white/10 dark:from-slate-900 dark:to-slate-950',
+        'border-border bg-card',
       )}
     >
       {/* Header */}
@@ -54,8 +53,8 @@ export function MiniFlameCard({
 
       {/* Footer — time budget */}
       {budgetLabel && (
-        <div className="bg-slate-200/70 px-1.5 py-1.5 dark:bg-black/30 sm:px-2">
-          <p className="text-center text-[10px] text-slate-500 dark:text-white/50 sm:text-xs">
+        <div className="bg-muted px-1.5 py-1.5 sm:px-2">
+          <p className="text-center text-[10px] text-muted-foreground sm:text-xs">
             {budgetLabel}
           </p>
         </div>

--- a/app/(app)/flames/schedule/components/dialog/FuelSlider.tsx
+++ b/app/(app)/flames/schedule/components/dialog/FuelSlider.tsx
@@ -256,7 +256,7 @@ export function FuelSlider({
         onPointerUp={handlePointerUp}
       >
         {/* Track */}
-        <div className="relative h-full overflow-hidden rounded-full bg-slate-200 dark:bg-white/10">
+        <div className="relative h-full overflow-hidden rounded-full bg-muted">
           {/* Segment ticks */}
           <div
             className="pointer-events-none absolute inset-0 z-10 rounded-full opacity-20 dark:opacity-15"
@@ -339,9 +339,7 @@ export function FuelSlider({
           type="text"
           className={cn(
             'w-14 shrink-0 border-b border-amber-400 bg-transparent text-center text-sm font-medium tabular-nums outline-none',
-            isOverCapacity
-              ? 'text-destructive'
-              : 'text-slate-600 dark:text-white/70',
+            isOverCapacity ? 'text-destructive' : 'text-muted-foreground',
           )}
           value={editText}
           onChange={(e) => setEditText(e.target.value)}
@@ -360,9 +358,7 @@ export function FuelSlider({
           disabled={disabled}
           className={cn(
             'w-14 shrink-0 cursor-text border-b border-transparent text-center text-sm font-medium tabular-nums hover:border-amber-400/50',
-            isOverCapacity
-              ? 'text-destructive'
-              : 'text-slate-600 dark:text-white/70',
+            isOverCapacity ? 'text-destructive' : 'text-muted-foreground',
           )}
         >
           {formatTime(value)}

--- a/app/globals.css
+++ b/app/globals.css
@@ -48,23 +48,23 @@
 }
 
 :root {
-  --background: oklch(1 0 0);
+  --background: oklch(0.98 0.005 80);
   --foreground: oklch(0.13 0.028 261.692);
-  --card: oklch(1 0 0);
+  --card: oklch(0.995 0.002 80);
   --card-foreground: oklch(0.13 0.028 261.692);
-  --popover: oklch(1 0 0);
+  --popover: oklch(0.995 0.002 80);
   --popover-foreground: oklch(0.13 0.028 261.692);
   --primary: oklch(59.2% 0.249 0.584);
   --primary-foreground: oklch(0.98 0.016 73.684);
-  --secondary: oklch(0.967 0.001 286.375);
+  --secondary: oklch(0.94 0.008 80);
   --secondary-foreground: oklch(0.21 0.006 285.885);
-  --muted: oklch(0.967 0.003 264.542);
+  --muted: oklch(0.94 0.008 80);
   --muted-foreground: oklch(0.551 0.027 264.364);
-  --accent: oklch(0.967 0.003 264.542);
+  --accent: oklch(0.94 0.008 80);
   --accent-foreground: oklch(0.21 0.034 264.665);
   --destructive: oklch(0.577 0.245 27.325);
-  --border: oklch(0.928 0.006 264.531);
-  --input: oklch(0.928 0.006 264.531);
+  --border: oklch(0.91 0.01 80);
+  --input: oklch(0.91 0.01 80);
   --ring: oklch(0.707 0.022 261.325);
   --chart-1: oklch(0.837 0.128 66.29);
   --chart-2: oklch(0.705 0.213 47.604);


### PR DESCRIPTION
## Summary
- Tune light mode CSS variables in `globals.css` — warm off-white background, distinct card surface, warmer muted/border/input values
- Replace hard-coded `slate`/`gray` Tailwind classes with theme tokens (`bg-card`, `bg-muted`, `text-foreground`, `border-border`, etc.) across 12 component files
- Add theme color conventions to `CLAUDE.md` to prevent future regressions

## Test plan
- [x] `pnpm build` passes
- [x] Light mode: cards have subtle warmth and depth vs background, footer sections softer, progress bar tracks blend well
- [x] Dark mode: no visual regressions
- [x] Verified flames page, schedule page, loading skeleton, bottom nav, seal summary modal

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive theme color guidelines to standardize design token usage across the application.

* **Style**
  * Enhanced visual consistency across all components by implementing unified theme color tokens.
  * Refined light theme palette with softer, more neutral tones for improved visual cohesion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->