### PR TITLE
polish(fnf): Flames page layout and FuelMeter

### DIFF
--- a/app/(app)/flames/components/FlamesList.tsx
+++ b/app/(app)/flames/components/FlamesList.tsx
@@ -4,6 +4,7 @@ import { useCallback, useState } from 'react';
 import type { Flame, FlameSession } from '@/utils/supabase/rows';
 import type { FuelBudgetStatus } from '../actions';
 import { endSession, getAllSessionsForDate } from '../session-actions';
+import { FlamesPageActions } from './FlamesPageActions';
 import { FuelMeter } from './FuelMeter';
 import { FlameCard } from './flame-card/FlameCard';
 import { useFuel } from './hooks/useFuel';
@@ -65,12 +66,21 @@ export function FlamesList({
 
   return (
     <div>
-      <FuelMeter
-        budgetSeconds={budgetSeconds}
-        remainingSeconds={remainingSeconds}
-        hasBudget={hasBudget}
-        isBurning={activeFlameId !== null}
-      />
+      <div className="sticky top-12 z-20 -mx-4 mb-4 bg-background/80 px-4 pb-0 backdrop-blur-sm md:top-14">
+        <div className="flex items-stretch gap-2">
+          <div className="min-w-0 flex-1">
+            <FuelMeter
+              budgetSeconds={budgetSeconds}
+              remainingSeconds={remainingSeconds}
+              hasBudget={hasBudget}
+              isBurning={activeFlameId !== null}
+            />
+          </div>
+          <div className="flex items-center gap-1 rounded-lg border border-border bg-card px-2">
+            <FlamesPageActions />
+          </div>
+        </div>
+      </div>
       <div className="grid grid-cols-2 gap-3 sm:gap-4 md:grid-cols-3 lg:grid-cols-4">
         {flames.map((flame, index) => (
           <FlameCard

--- a/app/(app)/flames/components/FuelMeter.tsx
+++ b/app/(app)/flames/components/FuelMeter.tsx
@@ -51,12 +51,8 @@ export function FuelMeter({
 
   if (!hasBudget) {
     return (
-      <div className="sticky top-0 z-20 -mx-4 mb-4 bg-background/80 px-4 pt-4 pb-0 backdrop-blur-sm">
-        <div className="rounded-lg border border-border bg-card px-3 py-2">
-          <p className="text-center text-xs text-muted-foreground">
-            {t('noBudget')}
-          </p>
-        </div>
+      <div className="flex h-full items-center justify-center rounded-lg border border-border bg-card px-3 py-2">
+        <p className="text-xs text-muted-foreground">{t('noBudget')}</p>
       </div>
     );
   }
@@ -94,191 +90,192 @@ export function FuelMeter({
     : 'rgba(245, 158, 11, 0.25)';
 
   return (
-    <div className="sticky top-0 z-20 -mx-4 mb-4 bg-background/80 px-4 pt-4 pb-0 backdrop-blur-sm">
-      <motion.div
-        className="rounded-lg border border-border bg-card px-3 py-2.5"
-        initial={false}
-        animate={
-          isBurning && !isDepleted && !shouldReduceMotion
-            ? {
-                boxShadow: [
-                  `0 0 8px ${glowColor}, 0 0 16px ${glowColor}`,
-                  `0 0 12px ${glowColorStrong}, 0 0 24px ${glowColor}`,
-                  `0 0 8px ${glowColor}, 0 0 16px ${glowColor}`,
-                ],
-              }
-            : { boxShadow: '0 0 0px transparent' }
-        }
-        transition={
-          isBurning && !isDepleted
-            ? {
-                duration: 3,
-                repeat: Number.POSITIVE_INFINITY,
-                ease: 'easeInOut',
-              }
-            : { duration: 0.4 }
-        }
-      >
-        <div className="flex items-center gap-2.5">
-          {/* Fuel icon + label */}
-          <div className={cn('flex shrink-0 items-center gap-1', iconColor)}>
-            <Fuel className="h-3.5 w-3.5" />
-            <span className="text-xs font-semibold uppercase tracking-wide">
-              {t('label')}
-            </span>
-          </div>
-
-          {/* Bar container */}
-          <div className="relative h-3 flex-1 overflow-visible">
-            <div className="relative h-full overflow-hidden rounded-full bg-muted">
-              {/* Segment ticks — repeating gradient overlay, auto-adapts to width */}
-              <div
-                className="pointer-events-none absolute inset-0 z-10 rounded-full opacity-20 dark:opacity-15"
-                aria-hidden
-                style={{
-                  backgroundImage: `
-                    repeating-linear-gradient(
-                      to right,
-                      transparent 0px,
-                      transparent 30px,
-                      rgba(0, 0, 0, 0.5) 30px,
-                      rgba(0, 0, 0, 0.5) 32px
-                    )
-                  `,
-                }}
-              />
-              {/* Fill bar */}
-              <motion.div
-                className={cn(
-                  'absolute inset-y-0 left-0 rounded-full',
-                  barColor,
-                )}
-                initial={{ width: 0 }}
-                animate={{ width: `${fraction * 100}%` }}
-                transition={
-                  shouldReduceMotion
-                    ? { duration: 0.2 }
-                    : { duration: 0.6, ease: [0.25, 0.1, 0.25, 1] as const }
-                }
-              >
-                {/* Glowing tip — hot-spot at the leading edge while burning */}
-                {isBurning && !isDepleted && (
-                  <motion.div
-                    className="absolute top-0 right-0 bottom-0 w-3 rounded-full"
-                    style={{
-                      background: isLow
-                        ? 'linear-gradient(to left, rgba(255,200,180,0.9), transparent)'
-                        : 'linear-gradient(to left, rgba(255,240,200,0.9), transparent)',
-                      boxShadow: isLow
-                        ? '0 0 6px rgba(239,68,68,0.6), 0 0 12px rgba(239,68,68,0.3)'
-                        : '0 0 6px rgba(251,191,36,0.6), 0 0 12px rgba(251,191,36,0.3)',
-                    }}
-                    initial={false}
-                    animate={
-                      shouldReduceMotion
-                        ? {}
-                        : {
-                            opacity: [0.7, 1, 0.7],
-                          }
-                    }
-                    transition={{
-                      duration: 1.5,
-                      repeat: Number.POSITIVE_INFINITY,
-                      ease: 'easeInOut',
-                    }}
-                  />
-                )}
-
-                {/* Consumption shimmer */}
-                {isBurning && !isDepleted && !shouldReduceMotion && (
-                  <motion.div
-                    className="absolute inset-0 rounded-full opacity-30"
-                    style={{
-                      backgroundImage:
-                        'linear-gradient(90deg, transparent 0%, rgba(255,255,255,0.4) 40%, transparent 60%)',
-                      backgroundSize: '200% 100%',
-                    }}
-                    animate={{ backgroundPosition: ['200% 0', '-200% 0'] }}
-                    transition={{
-                      duration: 2.5,
-                      repeat: Number.POSITIVE_INFINITY,
-                      ease: 'linear',
-                    }}
-                  />
-                )}
-              </motion.div>
-
-              {/* Low-fuel pulse overlay */}
-              <AnimatePresence>
-                {isLow && !isDepleted && !shouldReduceMotion && (
-                  <motion.div
-                    className="absolute inset-0 rounded-full bg-red-500/10 dark:bg-red-400/10"
-                    initial={{ opacity: 0 }}
-                    animate={{ opacity: [0, 0.4, 0] }}
-                    exit={{ opacity: 0 }}
-                    transition={{
-                      duration: 2,
-                      repeat: Number.POSITIVE_INFINITY,
-                      ease: 'easeInOut',
-                    }}
-                  />
-                )}
-              </AnimatePresence>
-
-              {/* Burn-start ripple */}
-              <AnimatePresence>
-                {showRipple && !shouldReduceMotion && (
-                  <motion.div
-                    className="absolute inset-0 rounded-full bg-amber-300/30 dark:bg-amber-400/20"
-                    initial={{ opacity: 0.6, scale: 1 }}
-                    animate={{ opacity: 0, scale: 1.05 }}
-                    exit={{ opacity: 0 }}
-                    transition={{ duration: 0.6, ease: 'easeOut' }}
-                  />
-                )}
-              </AnimatePresence>
-            </div>
-
-            {/* Tip effects — positioned at the leading edge of the fill */}
-            {isBurning && !isDepleted && !shouldReduceMotion && (
-              <div
-                className="pointer-events-none absolute top-0 h-full"
-                style={{ left: `${fraction * 100}%` }}
-              >
-                {/* Fuel droplets — drip downward */}
-                <FuelDroplets
-                  className={
-                    isLow
-                      ? 'bg-red-400/80 dark:bg-red-300/80'
-                      : 'bg-amber-500/70 dark:bg-amber-300/70'
-                  }
-                />
-
-                {/* Smoke puffs — soft blurred circles that accumulate into smoke */}
-                <SmokePuffs
-                  color={
-                    isLow
-                      ? 'rgba(252, 165, 165, 0.8)'
-                      : 'rgba(220, 180, 100, 0.7)'
-                  }
-                />
-              </div>
-            )}
-          </div>
-
-          {/* Time label */}
-          <span
-            className={cn(
-              'shrink-0 text-xs font-medium tabular-nums',
-              textColor,
-            )}
-          >
-            {isDepleted
-              ? t('depleted')
-              : t('remaining', { time: formatTime(remainingSeconds) })}
+    <motion.div
+      className="h-full rounded-lg border border-border bg-card px-3 py-2.5"
+      initial={false}
+      animate={
+        isBurning && !isDepleted && !shouldReduceMotion
+          ? {
+              boxShadow: [
+                `0 0 8px ${glowColor}, 0 0 16px ${glowColor}`,
+                `0 0 12px ${glowColorStrong}, 0 0 24px ${glowColor}`,
+                `0 0 8px ${glowColor}, 0 0 16px ${glowColor}`,
+              ],
+            }
+          : { boxShadow: '0 0 0px transparent' }
+      }
+      transition={
+        isBurning && !isDepleted
+          ? {
+              duration: 3,
+              repeat: Number.POSITIVE_INFINITY,
+              ease: 'easeInOut',
+            }
+          : { duration: 0.4 }
+      }
+    >
+      <div className="flex items-center gap-2.5">
+        {/* Fuel icon + label */}
+        <div className={cn('flex shrink-0 items-center gap-1', iconColor)}>
+          <Fuel className="h-3.5 w-3.5" />
+          <span className="text-xs font-semibold uppercase tracking-wide">
+            {t('label')}
           </span>
         </div>
-      </motion.div>
-    </div>
+
+        {/* Bar container */}
+        <div className="relative h-3 flex-1 overflow-visible">
+          <div className="relative h-full overflow-hidden rounded-full bg-muted">
+            {/* Segment ticks — repeating gradient overlay, auto-adapts to width */}
+            <div
+              className="pointer-events-none absolute inset-0 z-10 rounded-full opacity-20 dark:opacity-15"
+              aria-hidden
+              style={{
+                backgroundImage: `
+                  repeating-linear-gradient(
+                    to right,
+                    transparent 0px,
+                    transparent 30px,
+                    rgba(0, 0, 0, 0.5) 30px,
+                    rgba(0, 0, 0, 0.5) 32px
+                  )
+                `,
+              }}
+            />
+            {/* Fill bar */}
+            <motion.div
+              className={cn('absolute inset-y-0 left-0 rounded-full', barColor)}
+              initial={{ width: 0 }}
+              animate={{ width: `${fraction * 100}%` }}
+              transition={
+                shouldReduceMotion
+                  ? { duration: 0.2 }
+                  : { duration: 0.6, ease: [0.25, 0.1, 0.25, 1] as const }
+              }
+            >
+              {/* Glowing tip — hot-spot at the leading edge while burning */}
+              {isBurning && !isDepleted && (
+                <motion.div
+                  className="absolute top-0 right-0 bottom-0 w-3 rounded-full"
+                  style={{
+                    background: isLow
+                      ? 'linear-gradient(to left, rgba(255,200,180,0.9), transparent)'
+                      : 'linear-gradient(to left, rgba(255,240,200,0.9), transparent)',
+                    boxShadow: isLow
+                      ? '0 0 6px rgba(239,68,68,0.6), 0 0 12px rgba(239,68,68,0.3)'
+                      : '0 0 6px rgba(251,191,36,0.6), 0 0 12px rgba(251,191,36,0.3)',
+                  }}
+                  initial={false}
+                  animate={
+                    shouldReduceMotion
+                      ? {}
+                      : {
+                          opacity: [0.7, 1, 0.7],
+                        }
+                  }
+                  transition={{
+                    duration: 1.5,
+                    repeat: Number.POSITIVE_INFINITY,
+                    ease: 'easeInOut',
+                  }}
+                />
+              )}
+
+              {/* Consumption shimmer */}
+              {isBurning && !isDepleted && !shouldReduceMotion && (
+                <motion.div
+                  className="absolute inset-0 rounded-full opacity-30"
+                  style={{
+                    backgroundImage:
+                      'linear-gradient(90deg, transparent 0%, rgba(255,255,255,0.4) 40%, transparent 60%)',
+                    backgroundSize: '200% 100%',
+                  }}
+                  animate={{ backgroundPosition: ['200% 0', '-200% 0'] }}
+                  transition={{
+                    duration: 2.5,
+                    repeat: Number.POSITIVE_INFINITY,
+                    ease: 'linear',
+                  }}
+                />
+              )}
+            </motion.div>
+
+            {/* Low-fuel pulse overlay */}
+            <AnimatePresence>
+              {isLow && !isDepleted && !shouldReduceMotion && (
+                <motion.div
+                  className="absolute inset-0 rounded-full bg-red-500/10 dark:bg-red-400/10"
+                  initial={{ opacity: 0 }}
+                  animate={{ opacity: [0, 0.4, 0] }}
+                  exit={{ opacity: 0 }}
+                  transition={{
+                    duration: 2,
+                    repeat: Number.POSITIVE_INFINITY,
+                    ease: 'easeInOut',
+                  }}
+                />
+              )}
+            </AnimatePresence>
+
+            {/* Burn-start ripple */}
+            <AnimatePresence>
+              {showRipple && !shouldReduceMotion && (
+                <motion.div
+                  className="absolute inset-0 rounded-full bg-amber-300/30 dark:bg-amber-400/20"
+                  initial={{ opacity: 0.6, scale: 1 }}
+                  animate={{ opacity: 0, scale: 1.05 }}
+                  exit={{ opacity: 0 }}
+                  transition={{ duration: 0.6, ease: 'easeOut' }}
+                />
+              )}
+            </AnimatePresence>
+          </div>
+
+          {/* Tip effects — positioned at the leading edge of the fill */}
+          {isBurning && !isDepleted && !shouldReduceMotion && (
+            <div
+              className="pointer-events-none absolute top-0 h-full"
+              style={{ left: `${fraction * 100}%` }}
+            >
+              {/* Fuel droplets — drip downward */}
+              <FuelDroplets
+                className={
+                  isLow
+                    ? 'bg-red-400/80 dark:bg-red-300/80'
+                    : 'bg-amber-500/70 dark:bg-amber-300/70'
+                }
+              />
+
+              {/* Smoke puffs — soft blurred circles that accumulate into smoke */}
+              <SmokePuffs
+                color={
+                  isLow
+                    ? 'rgba(252, 165, 165, 0.8)'
+                    : 'rgba(220, 180, 100, 0.7)'
+                }
+              />
+            </div>
+          )}
+        </div>
+
+        {/* Time label — time only on mobile, full string on desktop */}
+        <span
+          className={cn('shrink-0 text-xs font-medium tabular-nums', textColor)}
+        >
+          {isDepleted ? (
+            t('depleted')
+          ) : (
+            <>
+              <span className="md:hidden">
+                {formatTime(remainingSeconds)}
+              </span>
+              <span className="hidden md:inline">
+                {t('remaining', { time: formatTime(remainingSeconds) })}
+              </span>
+            </>
+          )}
+        </span>
+      </div>
+    </motion.div>
   );
 }

--- a/app/(app)/flames/page.tsx
+++ b/app/(app)/flames/page.tsx
@@ -15,8 +15,7 @@ export default async function FlamesPage() {
   if (!result.success) {
     return (
       <div className="size-full p-4 pb-24">
-        <div className="flex items-center justify-between mb-4">
-          <h1 className="text-lg font-semibold">{t('todayTitle')}</h1>
+        <div className="flex justify-end mb-4">
           <FlamesPageActions />
         </div>
         <p>{t('loading')}</p>
@@ -28,12 +27,9 @@ export default async function FlamesPage() {
 
   return (
     <div className="size-full p-4 pb-24">
-      <div className="flex items-center justify-between mb-4">
-        <h1 className="text-lg font-semibold">{t('todayTitle')}</h1>
-        <FlamesPageActions />
-      </div>
       {flames.length === 0 ? (
         <div className="flex flex-col items-center justify-center gap-3 py-16 text-center">
+          <FlamesPageActions />
           <p className="text-muted-foreground text-sm">{t('emptyToday')}</p>
           <Link
             href="/flames/manage"


### PR DESCRIPTION
- Make the fuel meter sticky again
- Get rid of the redundant header component (doesnt give any additional info than already known so it was useless)
- Move schedule and manage nav buttons to same row as fuel meter
- Removes the 'remaining' label text for the fuel meter on mobile to save horizontal space

<img width="1134" height="1065" alt="image" src="https://github.com/user-attachments/assets/34f11890-7c2f-4311-a3fa-0fba64ad8ed4" />
<img width="424" height="935" alt="image" src="https://github.com/user-attachments/assets/d3aaa375-0617-44f7-a472-60cca827a06c" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Simplified the fuel meter design with a cleaner, flatter visual appearance.
  * Updated the flames page layout with a reorganized sticky header containing the fuel meter and action controls.
  * Streamlined header structure by repositioning page actions for improved visual clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->