### PR TITLE
fix: Show sealed text on flame cards when another flame is burning

### DIFF
--- a/app/(app)/flames/components/flame-card/FlameCard.tsx
+++ b/app/(app)/flames/components/flame-card/FlameCard.tsx
@@ -155,7 +155,7 @@ export function FlameCard({
 
   const getStateText = () => {
     if (isFuelBlocked && state !== 'sealed') return t('noFuel');
-    if (isBlocked) return null;
+    if (isBlocked && state !== 'sealed') return null;
     switch (state) {
       case 'untended':
         return t('ready');


### PR DESCRIPTION
The `isBlocked` guard in `getStateText()` returned null for all states including sealed, hiding the "Sealed" footer text when another flame was actively burning. Now sealed state is excluded from the blocked check, matching the existing pattern used for `isFuelBlocked`.