### PR TITLE
fix(fnf): Apply glass effect to fuel bar and nav buttons individually

### DIFF
--- a/app/(app)/flames/components/FlamesList.tsx
+++ b/app/(app)/flames/components/FlamesList.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import { useCallback, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { cn } from '@/lib/utils';
 import type { Flame, FlameSession } from '@/utils/supabase/rows';
 import type { FuelBudgetStatus } from '../actions';
 import { endSession, getAllSessionsForDate } from '../session-actions';
@@ -48,6 +49,23 @@ export function FlamesList({
     onFuelDepleted: handleFuelDepleted,
   });
 
+  // Detect when the fuel bar becomes sticky
+  const sentinelRef = useRef<HTMLDivElement>(null);
+  const [isStuck, setIsStuck] = useState(false);
+
+  useEffect(() => {
+    const sentinel = sentinelRef.current;
+    if (!sentinel) return;
+
+    const observer = new IntersectionObserver(
+      ([entry]) => setIsStuck(!entry.isIntersecting),
+      { rootMargin: '-48px 0px 0px 0px' },
+    );
+
+    observer.observe(sentinel);
+    return () => observer.disconnect();
+  }, []);
+
   const refreshSessions = useCallback(async () => {
     const result = await getAllSessionsForDate(date);
     if (result.success && result.data) {
@@ -66,6 +84,7 @@ export function FlamesList({
 
   return (
     <div>
+      <div ref={sentinelRef} className="h-0" />
       <div className="sticky top-12 z-20 -mx-4 mb-4 px-4 pt-2 md:top-14">
         <div className="flex items-stretch gap-2">
           <div className="min-w-0 flex-1">
@@ -74,9 +93,15 @@ export function FlamesList({
               remainingSeconds={remainingSeconds}
               hasBudget={hasBudget}
               isBurning={activeFlameId !== null}
+              isStuck={isStuck}
             />
           </div>
-          <div className="flex items-center gap-1 rounded-lg border border-border bg-card px-2 backdrop-blur-sm">
+          <div
+            className={cn(
+              'flex items-center gap-1 rounded-lg border border-border px-2 backdrop-blur-sm transition-[colors,opacity] duration-1000',
+              isStuck ? 'bg-card/50 opacity-90' : 'bg-card',
+            )}
+          >
             <FlamesPageActions />
           </div>
         </div>

--- a/app/(app)/flames/components/FuelMeter.tsx
+++ b/app/(app)/flames/components/FuelMeter.tsx
@@ -13,6 +13,7 @@ interface FuelMeterProps {
   remainingSeconds: number;
   hasBudget: boolean;
   isBurning: boolean;
+  isStuck?: boolean;
 }
 
 function formatTime(totalSeconds: number): string {
@@ -32,6 +33,7 @@ export function FuelMeter({
   remainingSeconds,
   hasBudget,
   isBurning,
+  isStuck = false,
 }: FuelMeterProps) {
   const t = useTranslations('flames.fuel');
   const shouldReduceMotion = useReducedMotion();
@@ -51,7 +53,12 @@ export function FuelMeter({
 
   if (!hasBudget) {
     return (
-      <div className="flex h-full items-center justify-center rounded-lg border border-border bg-card px-3 py-2 backdrop-blur-sm">
+      <div
+        className={cn(
+          'flex h-full items-center justify-center rounded-lg border border-border px-3 py-2 backdrop-blur-sm transition-[colors,opacity] duration-1000',
+          isStuck ? 'bg-card/50 opacity-90' : 'bg-card',
+        )}
+      >
         <p className="text-xs text-muted-foreground">{t('noBudget')}</p>
       </div>
     );
@@ -91,7 +98,10 @@ export function FuelMeter({
 
   return (
     <motion.div
-      className="h-full rounded-lg border border-border bg-card px-3 py-2.5 backdrop-blur-sm"
+      className={cn(
+        'h-full rounded-lg border border-border px-3 py-2.5 backdrop-blur-sm transition-[colors,opacity] duration-1000',
+        isStuck ? 'bg-card/50 opacity-90' : 'bg-card',
+      )}
       initial={false}
       animate={
         isBurning && !isDepleted && !shouldReduceMotion


### PR DESCRIPTION
The refactor that consolidated the sticky header moved the glass effect (bg-background/80 + backdrop-blur) to the parent wrapper, but the inner FuelMeter and nav buttons had opaque bg-card backgrounds covering it. Now each element gets its own glass pane. Also adds top padding to the sticky container to create spacing between it and the fixed header.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Refined visuals across flames-related components: subtle backdrop blur, adjusted backgrounds/opacity when sticky, and simplified mobile time rendering.

* **Bug Fixes**
  * State labels now display correctly when a sealed item is blocked.

* **New Features**
  * Fuel meter and action header now detect sticky scrolling and update their appearance and behavior.
  * Tweaked completion and overburn thresholds that affect completion bonuses and modal subtitles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->