### PR TITLE
ref(fnf): Rename Flame "Sealing" to "Completion"

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # Hibana
 
-Gamified habit tracker using fire/flame metaphors. Users create "flames" (habits), allocate daily "fuel" (time budgets), track sessions, and "seal" (complete) them with celebration animations.
+Gamified habit tracker using fire/flame metaphors. Users create "flames" (habits), allocate daily "fuel" (time budgets), track sessions, and "complete" them with celebration animations.
 
 ## Stack
 
@@ -32,9 +32,9 @@ messages/         # i18n translation files (en.json, ja.json)
 ## Domain Model
 
 - **Flame**: A habit/goal. Has name, color, icon, tracking_type (time|count), budget, schedule. Five visual levels: Candle, Torch, Blaze, Bonfire, Supernova.
-- **Flame State Machine**: untended → burning → paused → sealing → sealed
+- **Flame State Machine**: untended → burning → paused → completing → completed
 - **Flame Session**: A tracking instance (started_at, ended_at, duration_seconds, is_completed).
-- **Seal**: Completing a flame session. Triggers celebration animation.
+- **Completion**: Completing a flame session. Triggers celebration animation.
 - **Schedule**: `flame_schedules` — rolling weekly template (max 7 rows per user). Each row stores `fuel_budget`, `flame_ids[]`, and `flame_minutes[]` for one day-of-week. Flames are assigned to days through the schedule, not through per-flame `is_daily` flags.
 - **Flame Colors**: rose, orange, amber, indigo, teal, green, blue, sky, fuchsia (grouped: Earthly, Chemical, Cosmic).
 

--- a/app/(app)/flames/components/CompletionEmbers.tsx
+++ b/app/(app)/flames/components/CompletionEmbers.tsx
@@ -20,11 +20,11 @@ const EMBER_CONFIG = {
   driftRange: { min: -20, max: 20 },
 } as const;
 
-interface SealEmber extends Particle {
+interface CompletionEmber extends Particle {
   peakOpacity: number;
 }
 
-function createSealEmber(index: number): SealEmber {
+function createCompletionEmber(index: number): CompletionEmber {
   const base = generateFloatingParticle(index, EMBER_SEED, EMBER_CONFIG);
   const h = generateHash(index, 149);
   return {
@@ -33,13 +33,14 @@ function createSealEmber(index: number): SealEmber {
   };
 }
 
-interface SealEmbersProps {
+interface CompletionEmbersProps {
   color: string;
 }
 
-export function SealEmbers({ color }: SealEmbersProps) {
+export function CompletionEmbers({ color }: CompletionEmbersProps) {
   const particles = useMemo(
-    () => Array.from({ length: EMBER_COUNT }, (_, i) => createSealEmber(i)),
+    () =>
+      Array.from({ length: EMBER_COUNT }, (_, i) => createCompletionEmber(i)),
     [],
   );
 

--- a/app/(app)/flames/components/CompletionSummaryModal.tsx
+++ b/app/(app)/flames/components/CompletionSummaryModal.tsx
@@ -18,16 +18,16 @@ import {
 } from '@/components/ui/dialog';
 import {
   COMPLETION_THRESHOLD,
-  OVERBURN_GRACE,
   calculateSparks,
+  OVERBURN_GRACE,
 } from '@/lib/sparks';
+import { CompletionEmbers } from './CompletionEmbers';
+import { CompletionCelebration } from './flame-card/effects/CompletionCelebration';
 import { EffectsRenderer } from './flame-card/effects/EffectsRenderer';
 import { FlameRenderer } from './flame-card/effects/FlameRenderer';
-import { SealCelebration } from './flame-card/effects/SealCelebration';
 import type { EffectConfig, ShapeColors } from './flame-card/effects/types';
-import { SealEmbers } from './SealEmbers';
 
-interface SealSummaryModalProps {
+interface CompletionSummaryModalProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   flameName: string;
@@ -106,7 +106,7 @@ function useCountUp(target: number, active: boolean) {
   return value;
 }
 
-function SealFuelMeter({
+function CompletionFuelMeter({
   elapsedSeconds,
   targetSeconds,
   animate,
@@ -260,7 +260,7 @@ function SparkShower({ active }: { active: boolean }) {
   );
 }
 
-export function SealSummaryModal({
+export function CompletionSummaryModal({
   open,
   onOpenChange,
   flameName,
@@ -269,8 +269,8 @@ export function SealSummaryModal({
   effects,
   elapsedSeconds,
   targetSeconds,
-}: SealSummaryModalProps) {
-  const t = useTranslations('flames.seal');
+}: CompletionSummaryModalProps) {
+  const t = useTranslations('flames.completion');
   const shouldReduceMotion = useReducedMotion();
   const rewards = calculateRewards(elapsedSeconds, targetSeconds, level);
   const sparksRef = useRef<HTMLDivElement>(null);
@@ -318,7 +318,7 @@ export function SealSummaryModal({
 
     // Staggered animation sequence:
     // 200ms: Dialog open animation settles, fire celebration burst
-    // 500ms: Burst nearing end, reveal sealed flame (it has its own bounce-in)
+    // 500ms: Burst nearing end, reveal completed flame (it has its own bounce-in)
     // 700ms: Title + subtitle fade in
     // 1000ms: Fuel gauge animates
     // 1200ms: Stats slide up
@@ -367,7 +367,9 @@ export function SealSummaryModal({
         </DialogTitle>
 
         {/* Floating ember particles */}
-        {open && !shouldReduceMotion && <SealEmbers color={colors.light} />}
+        {open && !shouldReduceMotion && (
+          <CompletionEmbers color={colors.light} />
+        )}
 
         <div className="relative flex flex-col items-center gap-3 py-2">
           {/* Header text — at top */}
@@ -389,16 +391,16 @@ export function SealSummaryModal({
           {/* Hero flame visual — center of dialog */}
           <div className="relative flex h-36 w-36 items-center justify-center overflow-visible">
             {/* Celebration burst — plays on open */}
-            <SealCelebration
+            <CompletionCelebration
               active={burstActive}
               color={colors.medium}
               onComplete={handleBurstComplete}
             />
 
-            {/* Sealed flame — revealed after burst */}
+            {/* Completed flame — revealed after burst */}
             {showFlame && (
               <FlameRenderer
-                state="sealed"
+                state="completed"
                 level={level}
                 colors={colors}
                 className="h-28 w-24"
@@ -411,7 +413,7 @@ export function SealSummaryModal({
                 <div className="relative h-full w-full">
                   <EffectsRenderer
                     effects={effects}
-                    state="sealed"
+                    state="completed"
                     colors={colors}
                   />
                 </div>
@@ -427,7 +429,7 @@ export function SealSummaryModal({
               animate={showGauge ? { opacity: 1 } : {}}
               transition={{ duration: 0.3 }}
             >
-              <SealFuelMeter
+              <CompletionFuelMeter
                 elapsedSeconds={elapsedSeconds}
                 targetSeconds={targetSeconds}
                 animate={showGauge}

--- a/app/(app)/flames/components/completion-sounds.ts
+++ b/app/(app)/flames/components/completion-sounds.ts
@@ -1,11 +1,11 @@
 /**
- * Synthesized seal sound — plays during the long-press "seal" gesture.
+ * Synthesized completion sound — plays during the long-press "complete" gesture.
  * Crackling tension: noise grains that fire faster and faster,
- * building to a booming finish when the seal completes.
+ * building to a booming finish when the completion finishes.
  *
  * Uses Web Audio API — no audio files needed.
  *
- * Dev only: window.sealSound.demo() / .start() / .update(0.5) / .complete() / .cancel()
+ * Dev only: window.completionSound.demo() / .start() / .update(0.5) / .complete() / .cancel()
  */
 
 let ctx: AudioContext | null = null;
@@ -109,8 +109,8 @@ function stopDrone() {
 
 // ─── Public API ─────────────────────────────────────────────────────
 
-/** Start the crackling seal sound. Call once when sealing begins. */
-export function startSealSound() {
+/** Start the crackling completion sound. Call once when completing begins. */
+export function startCompletionSound() {
   const ac = getCtx();
   if (!ac) return;
   running = true;
@@ -137,8 +137,8 @@ export function startSealSound() {
   droneNodes = { osc, gain, filter };
 }
 
-/** Update crackling based on seal progress (0 → 1). Call every frame. */
-export function updateSealSound(progress: number) {
+/** Update crackling based on completion progress (0 → 1). Call every frame. */
+export function updateCompletionSound(progress: number) {
   if (!running) return;
   const ac = getCtx();
   if (!ac) return;
@@ -185,8 +185,8 @@ function makeDistortion(ac: AudioContext, amount: number): WaveShaperNode {
   return ws;
 }
 
-/** Seal completed — stop crackle, play boom. */
-export function completeSealSound() {
+/** Completion finished — stop crackle, play boom. */
+export function finishCompletionSound() {
   running = false;
   stopDrone();
   const ac = getCtx();
@@ -274,8 +274,8 @@ export function completeSealSound() {
   mid.stop(now + 0.2);
 }
 
-/** Seal cancelled — crackle fades out. */
-export function cancelSealSound() {
+/** Completion cancelled — crackle fades out. */
+export function cancelCompletionSound() {
   running = false;
   if (droneNodes) {
     const ac = getCtx();
@@ -298,26 +298,26 @@ export function cancelSealSound() {
 // ─── Dev console helpers (tree-shaken in production) ────────────────
 if (typeof window !== 'undefined' && process.env.NODE_ENV === 'development') {
   function runDemo() {
-    startSealSound();
+    startCompletionSound();
     const start = Date.now();
     const duration = 2000;
     const tick = () => {
       const p = Math.min((Date.now() - start) / duration, 1);
-      updateSealSound(p);
+      updateCompletionSound(p);
       if (p < 1) {
         requestAnimationFrame(tick);
       } else {
-        completeSealSound();
+        finishCompletionSound();
       }
     };
     requestAnimationFrame(tick);
   }
 
-  (window as unknown as Record<string, unknown>).sealSound = {
-    start: startSealSound,
-    update: updateSealSound,
-    complete: completeSealSound,
-    cancel: cancelSealSound,
+  (window as unknown as Record<string, unknown>).completionSound = {
+    start: startCompletionSound,
+    update: updateCompletionSound,
+    complete: finishCompletionSound,
+    cancel: cancelCompletionSound,
     demo: runDemo,
   };
 }

--- a/app/(app)/flames/components/flame-card/FlameCard.tsx
+++ b/app/(app)/flames/components/flame-card/FlameCard.tsx
@@ -4,24 +4,24 @@ import { motion, useReducedMotion } from 'framer-motion';
 import { useTranslations } from 'next-intl';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { toast } from 'sonner';
-import { creditSealReward } from '@/app/(app)/shop/actions';
+import { creditCompletionReward } from '@/app/(app)/shop/actions';
 import { cn } from '@/lib/utils';
 import type { Flame, FlameSession } from '@/utils/supabase/rows';
 import { getFlameColors } from '../../utils/colors';
 import { getFlameLevel } from '../../utils/levels';
+import { CompletionSummaryModal } from '../CompletionSummaryModal';
+import {
+  cancelCompletionSound,
+  finishCompletionSound,
+  startCompletionSound,
+  updateCompletionSound,
+} from '../completion-sounds';
 import { useFlameState } from '../hooks/useFlameState';
 import { useLongPress } from '../hooks/useLongPress';
-import { SealSummaryModal } from '../SealSummaryModal';
-import {
-  cancelSealSound,
-  completeSealSound,
-  startSealSound,
-  updateSealSound,
-} from '../seal-sounds';
+import { CompletionCelebration } from './effects/CompletionCelebration';
+import { CompletionRingProgress } from './effects/CompletionRingProgress';
 import { EffectsRenderer } from './effects/EffectsRenderer';
 import { FlameRenderer } from './effects/FlameRenderer';
-import { SealCelebration } from './effects/SealCelebration';
-import { SealRingProgress } from './effects/SealRingProgress';
 import { FlameGeometryProvider } from './FlameGeometryContext';
 import { FLAME_REGISTRY } from './flames';
 import { ProgressBar } from './ProgressBar';
@@ -37,7 +37,7 @@ interface FlameCardProps {
   level?: number;
 }
 
-const SEAL_DURATION_MS = 2000;
+const COMPLETION_DURATION_MS = 2000;
 
 export function FlameCard({
   flame,
@@ -49,7 +49,7 @@ export function FlameCard({
   level = 1,
 }: FlameCardProps) {
   const t = useTranslations('flames.card');
-  const tSeal = useTranslations('flames.seal');
+  const tCompletion = useTranslations('flames.completion');
   const shouldReduceMotion = useReducedMotion();
   const colors = getFlameColors(flame.color);
   const levelInfo = getFlameLevel(level);
@@ -62,10 +62,10 @@ export function FlameCard({
     isOverburning,
     toggle,
     isLoading,
-    isSealReady,
-    beginSealing,
-    cancelSealing,
-    completeSeal,
+    isCompletionReady,
+    beginCompletion,
+    cancelCompletion,
+    completeFlame,
   } = useFlameState({
     flame,
     session,
@@ -77,54 +77,54 @@ export function FlameCard({
   const [celebrationActive, setCelebrationActive] = useState(false);
 
   // Threshold: only treat as "long press" after 5% of duration (~100ms)
-  const SEAL_INTENT_THRESHOLD = 0.05;
+  const COMPLETION_INTENT_THRESHOLD = 0.05;
 
-  const handleSealComplete = useCallback(async () => {
-    if (!shouldReduceMotion) completeSealSound();
+  const handleCompletionFinish = useCallback(async () => {
+    if (!shouldReduceMotion) finishCompletionSound();
 
     setCelebrationActive(true);
 
     // Server action + spark reward run in background
     try {
-      const success = await completeSeal();
+      const success = await completeFlame();
       if (success) {
-        creditSealReward(flame.id, date).then((r) => {
+        creditCompletionReward(flame.id, date).then((r) => {
           if (!r.success)
-            console.error('Failed to credit seal reward:', r.error);
+            console.error('Failed to credit completion reward:', r.error);
         });
       } else {
-        toast.error(tSeal('error'), { position: 'top-center' });
+        toast.error(tCompletion('error'), { position: 'top-center' });
       }
     } catch {
-      toast.error(tSeal('error'), { position: 'top-center' });
+      toast.error(tCompletion('error'), { position: 'top-center' });
     }
-  }, [completeSeal, tSeal, flame.id, date, shouldReduceMotion]);
+  }, [completeFlame, tCompletion, flame.id, date, shouldReduceMotion]);
 
   const handleCelebrationComplete = useCallback(() => {
     setCelebrationActive(false);
     setShowSummary(true);
   }, []);
 
-  const canSeal = isSealReady && !isBlocked;
+  const canComplete = isCompletionReady && !isBlocked;
 
   const longPress = useLongPress({
-    duration: SEAL_DURATION_MS,
-    enabled: canSeal,
+    duration: COMPLETION_DURATION_MS,
+    enabled: canComplete,
     onProgress: (p) => {
-      // Only enter sealing state after meaningful hold
-      if (p > SEAL_INTENT_THRESHOLD && state !== 'sealing') {
-        beginSealing();
-        if (!shouldReduceMotion) startSealSound();
+      // Only enter completing state after meaningful hold
+      if (p > COMPLETION_INTENT_THRESHOLD && state !== 'completing') {
+        beginCompletion();
+        if (!shouldReduceMotion) startCompletionSound();
       }
-      // Update seal sound pitch/volume each frame
-      if (state === 'sealing' && !shouldReduceMotion) {
-        updateSealSound(p);
+      // Update completion sound pitch/volume each frame
+      if (state === 'completing' && !shouldReduceMotion) {
+        updateCompletionSound(p);
       }
     },
-    onComplete: handleSealComplete,
+    onComplete: handleCompletionFinish,
     onCancel: () => {
-      if (!shouldReduceMotion) cancelSealSound();
-      cancelSealing();
+      if (!shouldReduceMotion) cancelCompletionSound();
+      cancelCompletion();
     },
   });
 
@@ -135,11 +135,11 @@ export function FlameCard({
   }, [toggle, longPress.longPressTriggered]);
 
   const isActive = state === 'burning';
-  const isSealing = state === 'sealing';
-  const isSealed = state === 'sealed';
-  const isFuelBlocked = isFuelDepleted && !canSeal;
+  const isCompleting = state === 'completing';
+  const isCompleted = state === 'completed';
+  const isFuelBlocked = isFuelDepleted && !canComplete;
   const isDisabled =
-    isLoading || isSealed || isBlocked || isFuelBlocked || isSealing;
+    isLoading || isCompleted || isBlocked || isFuelBlocked || isCompleting;
 
   const getAriaLabel = () => {
     const baseName = flame.name;
@@ -151,30 +151,30 @@ export function FlameCard({
       case 'burning':
         return `${baseName}. ${t('burning')}`;
       case 'paused':
-        return canSeal
-          ? `${baseName}. ${t('readyToSeal')}`
+        return canComplete
+          ? `${baseName}. ${t('readyToComplete')}`
           : `${baseName}. ${t('resting')}`;
-      case 'sealing':
-        return `${baseName}. ${t('sealing')}`;
-      case 'sealed':
-        return `${baseName}. ${t('sealed')}`;
+      case 'completing':
+        return `${baseName}. ${t('completing')}`;
+      case 'completed':
+        return `${baseName}. ${t('completed')}`;
     }
   };
 
   const getStateText = () => {
-    if (isFuelBlocked && state !== 'sealed') return t('noFuel');
-    if (isBlocked && state !== 'sealed') return null;
+    if (isFuelBlocked && state !== 'completed') return t('noFuel');
+    if (isBlocked && state !== 'completed') return null;
     switch (state) {
       case 'untended':
         return t('ready');
       case 'burning':
         return isOverburning ? t('overburning') : t('burning');
       case 'paused':
-        return canSeal ? t('readyToSeal') : t('resting');
-      case 'sealing':
-        return t('sealing');
-      case 'sealed':
-        return t('sealed');
+        return canComplete ? t('readyToComplete') : t('resting');
+      case 'completing':
+        return t('completing');
+      case 'completed':
+        return t('completed');
     }
   };
 
@@ -201,11 +201,11 @@ export function FlameCard({
           boxShadow: `0 0 15px ${colors.medium}50, 0 0 30px ${colors.medium}25`,
           borderColor: colors.medium,
         }
-    : canSeal || isSealing
+    : canComplete || isCompleting
       ? {
           borderColor: '#fbbf24',
         }
-      : isSealed
+      : isCompleted
         ? { borderColor: '#64748b50' }
         : {};
 
@@ -256,14 +256,14 @@ export function FlameCard({
                 state={state}
                 colors={colors}
                 isOverburning={isOverburning}
-                isSealReady={canSeal}
+                isCompletionReady={canComplete}
               />
             </div>
           </div>
         </div>
       </FlameGeometryProvider>
 
-      <SealCelebration
+      <CompletionCelebration
         active={celebrationActive}
         color={colors.medium}
         onComplete={handleCelebrationComplete}
@@ -278,25 +278,28 @@ export function FlameCard({
           'relative flex w-full flex-col overflow-hidden rounded-xl border transition-colors',
           'border-border bg-card text-foreground',
           'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 cursor-pointer',
-          (canSeal || isSealing) && 'animate-seal-ready-glow',
-          isSealed && 'cursor-default',
+          (canComplete || isCompleting) && 'animate-completion-ready-glow',
+          isCompleted && 'cursor-default',
           isFuelBlocked && 'cursor-default opacity-40',
           isBlocked && 'cursor-default opacity-40',
           isLoading && 'cursor-wait',
         )}
         style={{
           ...borderGlowStyle,
-          ...(canSeal ? { touchAction: 'none' } : {}),
+          ...(canComplete ? { touchAction: 'none' } : {}),
         }}
         initial="rest"
         whileTap={isDisabled ? 'rest' : 'pressed'}
         variants={cardVariants}
         transition={cardTransition}
-        {...(canSeal || isSealing ? longPress.handlers : {})}
+        {...(canComplete || isCompleting ? longPress.handlers : {})}
       >
         {/* Header - Name and Level */}
         <div
-          className={cn('px-2 pt-2 sm:px-3 sm:pt-3', isSealed && 'opacity-50')}
+          className={cn(
+            'px-2 pt-2 sm:px-3 sm:pt-3',
+            isCompleted && 'opacity-50',
+          )}
         >
           <h3 className="truncate text-center text-xs font-semibold leading-tight sm:text-sm md:text-base">
             {flame.name}
@@ -315,18 +318,21 @@ export function FlameCard({
             state={state}
             level={level}
             colors={colors}
-            sealProgress={isSealing ? longPress.progress : 0}
+            completionProgress={isCompleting ? longPress.progress : 0}
             isOverburning={isOverburning}
           />
 
-          {/* Seal ring progress overlay */}
-          <SealRingProgress progress={longPress.progress} visible={isSealing} />
+          {/* Completion ring progress overlay */}
+          <CompletionRingProgress
+            progress={longPress.progress}
+            visible={isCompleting}
+          />
         </div>
 
         {/* Footer - Timer, Progress, State */}
         <div className="flex flex-col gap-1 bg-muted px-2 py-2 sm:gap-1.5 sm:px-3 sm:py-3">
           {flame.tracking_type === 'time' && targetSeconds > 0 && (
-            <div className={cn(isSealed && 'opacity-40')}>
+            <div className={cn(isCompleted && 'opacity-40')}>
               <TimerDisplay
                 elapsedSeconds={elapsedSeconds}
                 targetSeconds={targetSeconds}
@@ -347,16 +353,16 @@ export function FlameCard({
           <div
             className={cn(
               'text-center text-[10px] sm:text-xs',
-              canSeal || isSealing
+              canComplete || isCompleting
                 ? 'font-medium text-amber-500'
                 : isOverburning
                   ? 'font-medium text-red-500'
-                  : isSealed
+                  : isCompleted
                     ? 'font-medium'
                     : 'text-muted-foreground',
             )}
           >
-            {isSealed ? (
+            {isCompleted ? (
               <span
                 className="bg-clip-text text-transparent"
                 style={{
@@ -383,7 +389,7 @@ export function FlameCard({
         )}
       </motion.button>
 
-      <SealSummaryModal
+      <CompletionSummaryModal
         open={showSummary}
         onOpenChange={setShowSummary}
         flameName={flame.name}

--- a/app/(app)/flames/components/flame-card/ProgressBar.tsx
+++ b/app/(app)/flames/components/flame-card/ProgressBar.tsx
@@ -15,7 +15,7 @@ interface ProgressBarProps {
   isOverburning?: boolean;
 }
 
-const SEALED_BAR_GRADIENT =
+const COMPLETED_BAR_GRADIENT =
   'linear-gradient(to right, #92400e, #d97706, #f59e0b, #fbbf24)';
 
 const OVERBURN_BAR_GRADIENT =
@@ -29,12 +29,12 @@ export function ProgressBar({
 }: ProgressBarProps) {
   const shouldReduceMotion = useReducedMotion();
   const isActive = state === 'burning';
-  const isSealed = state === 'sealed';
+  const isCompleted = state === 'completed';
 
-  const percentage = isSealed ? 100 : Math.round(progress * 100);
+  const percentage = isCompleted ? 100 : Math.round(progress * 100);
 
-  const barBackground = isSealed
-    ? SEALED_BAR_GRADIENT
+  const barBackground = isCompleted
+    ? COMPLETED_BAR_GRADIENT
     : isOverburning
       ? OVERBURN_BAR_GRADIENT
       : `linear-gradient(to right, ${colors.dark}, ${colors.medium}, ${colors.light})`;
@@ -43,7 +43,7 @@ export function ProgressBar({
     ? isOverburning
       ? '0 0 8px #ef4444, 0 0 16px #ef444440'
       : `0 0 8px ${colors.medium}, 0 0 16px ${colors.medium}40`
-    : isSealed
+    : isCompleted
       ? '0 0 6px #d9770640'
       : 'none';
 

--- a/app/(app)/flames/components/flame-card/TimerDisplay.tsx
+++ b/app/(app)/flames/components/flame-card/TimerDisplay.tsx
@@ -54,7 +54,7 @@ export function TimerDisplay({
   };
 
   const textColorClass =
-    state === 'sealed'
+    state === 'completed'
       ? '' // Use inline color prop for completed state
       : isOverburning
         ? 'text-red-500 dark:text-red-400'
@@ -63,7 +63,7 @@ export function TimerDisplay({
   return (
     <motion.div
       className={`text-center font-mono text-[10px] tracking-tight sm:text-xs md:text-sm ${textColorClass}`}
-      style={state === 'sealed' ? { color } : undefined}
+      style={state === 'completed' ? { color } : undefined}
       animate={pulseAnimation}
       transition={pulseTransition}
     >

--- a/app/(app)/flames/components/flame-card/effects/CompletedSmokeWisps.tsx
+++ b/app/(app)/flames/components/flame-card/effects/CompletedSmokeWisps.tsx
@@ -3,7 +3,7 @@
 import { motion, useReducedMotion } from 'framer-motion';
 import { useCallback, useEffect, useId, useMemo, useRef } from 'react';
 
-interface SealedSmokeWispsProps {
+interface CompletedSmokeWispsProps {
   /** Y coordinate of the wick / emission point in the 0-100 SVG viewBox */
   wickY: number;
   /** X coordinate of the emission origin (default: 50 = center) */
@@ -407,13 +407,13 @@ function buildPaths(
 // Component
 // ---------------------------------------------------------------------------
 
-export function SealedSmokeWisps({
+export function CompletedSmokeWisps({
   wickY,
   wickX = 50,
   color,
   riseHeight: riseHeightProp,
   simple = false,
-}: SealedSmokeWispsProps) {
+}: CompletedSmokeWispsProps) {
   const shouldReduceMotion = useReducedMotion();
   const rawId = useId();
   const id = rawId.replace(/:/g, '');

--- a/app/(app)/flames/components/flame-card/effects/CompletionCelebration.tsx
+++ b/app/(app)/flames/components/flame-card/effects/CompletionCelebration.tsx
@@ -4,7 +4,7 @@ import { motion, useReducedMotion } from 'framer-motion';
 import { useEffect, useMemo, useState } from 'react';
 import { generateHash } from '../../particles';
 
-interface SealCelebrationProps {
+interface CompletionCelebrationProps {
   active: boolean;
   color: string;
   onComplete: () => void;
@@ -13,7 +13,7 @@ interface SealCelebrationProps {
 const PARTICLE_COUNT = 20;
 const DURATION_MS = 600;
 const GOLDEN_COLORS = ['#fbbf24', '#f59e0b', '#d97706', '#fcd34d'];
-const SEAL_GOLD = '#fbbf24';
+const COMPLETION_GOLD = '#fbbf24';
 
 interface CelebrationParticle {
   id: number;
@@ -24,11 +24,11 @@ interface CelebrationParticle {
   delay: number;
 }
 
-export function SealCelebration({
+export function CompletionCelebration({
   active,
   color,
   onComplete,
-}: SealCelebrationProps) {
+}: CompletionCelebrationProps) {
   const shouldReduceMotion = useReducedMotion();
   const [visible, setVisible] = useState(false);
 
@@ -73,7 +73,7 @@ export function SealCelebration({
         initial={{ opacity: 0 }}
         animate={{ opacity: [0, 0.4, 0] }}
         transition={{ duration: 0.5 }}
-        style={{ backgroundColor: SEAL_GOLD }}
+        style={{ backgroundColor: COMPLETION_GOLD }}
       />
     );
   }
@@ -84,7 +84,7 @@ export function SealCelebration({
       <motion.div
         className="absolute rounded-full"
         style={{
-          border: `2px solid ${SEAL_GOLD}`,
+          border: `2px solid ${COMPLETION_GOLD}`,
         }}
         initial={{ width: 0, height: 0, opacity: 0.9 }}
         animate={{ width: 160, height: 160, opacity: 0 }}
@@ -94,7 +94,7 @@ export function SealCelebration({
       <motion.div
         className="absolute rounded-full"
         style={{
-          border: `1.5px solid ${SEAL_GOLD}`,
+          border: `1.5px solid ${COMPLETION_GOLD}`,
         }}
         initial={{ width: 0, height: 0, opacity: 0.6 }}
         animate={{ width: 120, height: 120, opacity: 0 }}

--- a/app/(app)/flames/components/flame-card/effects/CompletionRingProgress.tsx
+++ b/app/(app)/flames/components/flame-card/effects/CompletionRingProgress.tsx
@@ -2,7 +2,7 @@
 
 import { AnimatePresence, motion } from 'framer-motion';
 
-interface SealRingProgressProps {
+interface CompletionRingProgressProps {
   progress: number;
   visible: boolean;
 }
@@ -11,9 +11,12 @@ const RING_SIZE = 120;
 const STROKE_WIDTH = 8;
 const RADIUS = (RING_SIZE - STROKE_WIDTH) / 2;
 const CIRCUMFERENCE = 2 * Math.PI * RADIUS;
-const SEAL_COLOR = '#fbbf24';
+const COMPLETION_COLOR = '#fbbf24';
 
-export function SealRingProgress({ progress, visible }: SealRingProgressProps) {
+export function CompletionRingProgress({
+  progress,
+  visible,
+}: CompletionRingProgressProps) {
   const offset = CIRCUMFERENCE * (1 - progress);
 
   return (
@@ -39,7 +42,7 @@ export function SealRingProgress({ progress, visible }: SealRingProgressProps) {
               cy={RING_SIZE / 2}
               r={RADIUS}
               fill="none"
-              stroke={SEAL_COLOR}
+              stroke={COMPLETION_COLOR}
               strokeWidth={STROKE_WIDTH}
               opacity={0.15}
             />
@@ -49,7 +52,7 @@ export function SealRingProgress({ progress, visible }: SealRingProgressProps) {
               cy={RING_SIZE / 2}
               r={RADIUS}
               fill="none"
-              stroke={SEAL_COLOR}
+              stroke={COMPLETION_COLOR}
               strokeWidth={STROKE_WIDTH}
               strokeDasharray={CIRCUMFERENCE}
               strokeLinecap="round"

--- a/app/(app)/flames/components/flame-card/effects/EffectsRenderer.tsx
+++ b/app/(app)/flames/components/flame-card/effects/EffectsRenderer.tsx
@@ -4,10 +4,10 @@ import { useMemo } from 'react';
 import type { FlameState } from '../../../utils/types';
 import type { ParticleConditions } from '../../particles';
 import { FlameParticles } from '../../particles';
-import { SealedSmokeWisps } from './SealedSmokeWisps';
+import { CompletedSmokeWisps } from './CompletedSmokeWisps';
 import type {
+  CompletedSmokeEffectConfig,
   EffectConfig,
-  SealedSmokeEffectConfig,
   ShapeColors,
 } from './types';
 
@@ -16,15 +16,15 @@ interface EffectsRendererProps {
   state: FlameState;
   colors: ShapeColors;
   isOverburning?: boolean;
-  isSealReady?: boolean;
+  isCompletionReady?: boolean;
 }
 
-function isSealedSmokeEffect(
+function isCompletedSmokeEffect(
   effect: EffectConfig,
-): effect is SealedSmokeEffectConfig {
+): effect is CompletedSmokeEffectConfig {
   return (
     'type' in effect &&
-    (effect as SealedSmokeEffectConfig).type === 'sealedSmoke'
+    (effect as CompletedSmokeEffectConfig).type === 'completedSmoke'
   );
 }
 
@@ -33,18 +33,18 @@ export function EffectsRenderer({
   state,
   colors,
   isOverburning = false,
-  isSealReady = false,
+  isCompletionReady = false,
 }: EffectsRendererProps) {
   const conditions: ParticleConditions = useMemo(
-    () => ({ sealReady: isSealReady, overburning: isOverburning }),
-    [isSealReady, isOverburning],
+    () => ({ completionReady: isCompletionReady, overburning: isOverburning }),
+    [isCompletionReady, isOverburning],
   );
 
   return (
     <>
       {effects.map((effect) => {
-        if (isSealedSmokeEffect(effect)) {
-          if (state !== 'sealed') return null;
+        if (isCompletedSmokeEffect(effect)) {
+          if (state !== 'completed') return null;
           return (
             <div
               key={effect.type}
@@ -56,7 +56,7 @@ export function EffectsRenderer({
                 overflow="visible"
                 role="graphics-symbol"
               >
-                <SealedSmokeWisps
+                <CompletedSmokeWisps
                   wickY={effect.wickY}
                   wickX={effect.wickX}
                   color={effect.useFlameColor ? colors.medium : undefined}

--- a/app/(app)/flames/components/flame-card/effects/FlameRenderer.tsx
+++ b/app/(app)/flames/components/flame-card/effects/FlameRenderer.tsx
@@ -11,8 +11,8 @@ const stateVariants: Record<FlameState, TargetAndTransition> = {
   untended: { scale: 0.8, opacity: 0.88, y: 0 },
   burning: { scale: 1.1, opacity: 1, y: -4 },
   paused: { scale: 1, opacity: 0.95, y: 0 },
-  sealing: { scale: 1.15, opacity: 1, y: -6 },
-  sealed: { scale: 0, opacity: 1, y: 0.9 },
+  completing: { scale: 1.15, opacity: 1, y: -6 },
+  completed: { scale: 0, opacity: 1, y: 0.9 },
 };
 
 const DEFAULT_SVG_CLASS = 'h-24 w-20 sm:h-36 sm:w-28 md:h-44 md:w-36';
@@ -23,7 +23,7 @@ const springTransition = {
   damping: 20,
 };
 const fadeInTransition = { duration: 0.4, ease: 'easeOut' as const };
-const sealBounceTransition = {
+const completionBounceTransition = {
   type: 'spring' as const,
   stiffness: 120,
   damping: 12,
@@ -33,7 +33,7 @@ interface FlameRendererProps {
   state: FlameState;
   level: number;
   colors: ShapeColors;
-  sealProgress?: number;
+  completionProgress?: number;
   className?: string;
   isOverburning?: boolean;
 }
@@ -42,20 +42,21 @@ export function FlameRenderer({
   state,
   level,
   colors,
-  sealProgress = 0,
+  completionProgress = 0,
   className,
   isOverburning = false,
 }: FlameRendererProps) {
   const shouldReduceMotion = useReducedMotion();
   const clampedLevel = Math.max(1, Math.min(8, level));
-  const { Base, Flame, SealedFlame, animation } = FLAME_REGISTRY[clampedLevel];
+  const { Base, Flame, CompletedFlame, animation } =
+    FLAME_REGISTRY[clampedLevel];
   const svgClass = className ?? DEFAULT_SVG_CLASS;
 
   const fadeInInitial = shouldReduceMotion ? {} : { opacity: 0 };
 
-  // Sealed state: bounce from sealing peak then settle into resting visual
-  if (state === 'sealed') {
-    const hasSealedFlame = !!SealedFlame;
+  // Completed state: bounce from completing peak then settle into resting visual
+  if (state === 'completed') {
+    const hasCompletedFlame = !!CompletedFlame;
     return (
       <motion.svg
         viewBox="0 0 100 100"
@@ -65,13 +66,16 @@ export function FlameRenderer({
         initial={{ scale: 1.2, y: -6, ...fadeInInitial }}
         animate={{
           scale: 0.85,
-          opacity: hasSealedFlame ? 1 : 0.7,
+          opacity: hasCompletedFlame ? 1 : 0.7,
           y: 0,
         }}
-        transition={{ ...sealBounceTransition, opacity: fadeInTransition }}
+        transition={{
+          ...completionBounceTransition,
+          opacity: fadeInTransition,
+        }}
       >
-        {SealedFlame ? (
-          <SealedFlame colors={colors} />
+        {CompletedFlame ? (
+          <CompletedFlame colors={colors} />
         ) : (
           <>
             {Base && <Base />}
@@ -99,14 +103,18 @@ export function FlameRenderer({
     );
   }
 
-  // Compute SVG animate values: dynamic for sealing, from stateVariants otherwise
-  const isSealing = state === 'sealing';
-  const svgAnimate = isSealing
-    ? { scale: 0.8 + sealProgress * 0.35, y: sealProgress * -6, opacity: 1 }
+  // Compute SVG animate values: dynamic for completing, from stateVariants otherwise
+  const isCompleting = state === 'completing';
+  const svgAnimate = isCompleting
+    ? {
+        scale: 0.8 + completionProgress * 0.35,
+        y: completionProgress * -6,
+        opacity: 1,
+      }
     : isOverburning
       ? { scale: 1.25, opacity: 1, y: -6 }
       : stateVariants[state];
-  const svgTransition = isSealing
+  const svgTransition = isCompleting
     ? { type: 'tween' as const, duration: 0.1, ease: 'linear' as const }
     : springTransition;
 
@@ -119,8 +127,8 @@ export function FlameRenderer({
 
   return (
     <ShakeWrapper
-      active={isSealing && !shouldReduceMotion}
-      progress={sealProgress}
+      active={isCompleting && !shouldReduceMotion}
+      progress={completionProgress}
     >
       <motion.svg
         viewBox="0 0 100 100"

--- a/app/(app)/flames/components/flame-card/effects/presets.ts
+++ b/app/(app)/flames/components/flame-card/effects/presets.ts
@@ -2,7 +2,7 @@ import type { TargetAndTransition } from 'framer-motion';
 import type { FlameState } from '../../../utils/types';
 import type { FlameParticleEffect, ParticleStateConfig } from '../../particles';
 import { generateHash } from '../../particles';
-import type { SealedSmokeEffectConfig } from './types';
+import type { CompletedSmokeEffectConfig } from './types';
 
 // ---------------------------------------------------------------------------
 // Animation variant maps
@@ -21,11 +21,11 @@ export const FLICKER_VARIANTS: Record<FlameState, TargetAndTransition> = {
     scaleY: [1, 0.98, 1.01, 0.99, 1],
     scaleX: [1, 1.01, 0.99, 1.005, 1],
   },
-  sealing: {
+  completing: {
     scaleY: [1, 1.12, 0.88, 1.15, 0.85, 1.1, 1],
     scaleX: [1, 0.9, 1.1, 0.88, 1.12, 0.92, 1],
   },
-  sealed: {
+  completed: {
     scaleY: 1,
     scaleX: 1,
   },
@@ -44,11 +44,11 @@ export const RADIATE_VARIANTS: Record<FlameState, TargetAndTransition> = {
     scale: [1, 1.05, 1.02, 1.04, 1],
     rotate: [0, 2, -1, 1, 0],
   },
-  sealing: {
+  completing: {
     scale: [1, 1.18, 1.05, 1.2, 1.08, 1.15, 1],
     rotate: [0, 6, -4, 5, -3, 4, 0],
   },
-  sealed: {
+  completed: {
     scale: 1,
     rotate: 0,
   },
@@ -62,16 +62,16 @@ export const FLICKER_DURATIONS: Record<FlameState, number> = {
   untended: 2,
   burning: 0.8,
   paused: 2,
-  sealing: 0,
-  sealed: 0,
+  completing: 0,
+  completed: 0,
 };
 
 export const RADIATE_DURATIONS: Record<FlameState, number> = {
   untended: 3,
   burning: 2,
   paused: 3,
-  sealing: 1.2,
-  sealed: 0,
+  completing: 1.2,
+  completed: 0,
 };
 
 // ---------------------------------------------------------------------------
@@ -91,21 +91,21 @@ const STANDARD_EMBER_STATES: ParticleStateConfig = {
   burning: { count: 16, sizeMultiplier: 1.4 },
   paused: { count: 5, sizeMultiplier: 1 },
   untended: { count: 1, sizeMultiplier: 1 },
-  sealing: { count: 12, sizeMultiplier: 1.6 },
-  sealed: { count: 0, sizeMultiplier: 0 },
+  completing: { count: 12, sizeMultiplier: 1.6 },
+  completed: { count: 0, sizeMultiplier: 0 },
 };
 
 const WISP_EMBER_STATES: ParticleStateConfig = {
   burning: { count: 12, sizeMultiplier: 2.4 },
   paused: { count: 5, sizeMultiplier: 1 },
   untended: { count: 3, sizeMultiplier: 1 },
-  sealing: { count: 24, sizeMultiplier: 1.6 },
-  sealed: { count: 3, sizeMultiplier: 0.6 },
+  completing: { count: 24, sizeMultiplier: 1.6 },
+  completed: { count: 3, sizeMultiplier: 0.6 },
 };
 
-const SEAL_READY_PALETTE: FlameParticleEffect['modifiers'] = [
+const COMPLETION_READY_PALETTE: FlameParticleEffect['modifiers'] = [
   {
-    condition: 'sealReady',
+    condition: 'completionReady',
     palette: (colors) => [
       colors.light,
       '#fbbf24',
@@ -131,15 +131,15 @@ export const EMBER_EFFECT: FlameParticleEffect = {
       x: [0, particle.drift],
     }),
   },
-  modifiers: SEAL_READY_PALETTE,
+  modifiers: COMPLETION_READY_PALETTE,
 };
 
 const DANCING_EMBER_STATES: ParticleStateConfig = {
   burning: { count: 3, sizeMultiplier: 1 },
   paused: { count: 1, sizeMultiplier: 1 },
   untended: { count: 0, sizeMultiplier: 1 },
-  sealing: { count: 3, sizeMultiplier: 1 },
-  sealed: { count: 0, sizeMultiplier: 0 },
+  completing: { count: 3, sizeMultiplier: 1 },
+  completed: { count: 0, sizeMultiplier: 0 },
 };
 
 /** Fast wiggly embers that rise in an S-shaped sine path */
@@ -183,7 +183,7 @@ export const DANCING_EMBER_EFFECT: FlameParticleEffect = {
       };
     },
   },
-  modifiers: SEAL_READY_PALETTE,
+  modifiers: COMPLETION_READY_PALETTE,
 };
 
 export const WISP_EMBER_EFFECT: FlameParticleEffect = {
@@ -195,8 +195,8 @@ export const STANDARD_SMOKE_STATES: ParticleStateConfig = {
   burning: { count: 15, sizeMultiplier: 1.5 },
   paused: { count: 4, sizeMultiplier: 1 },
   untended: { count: 2, sizeMultiplier: 1 },
-  sealing: { count: 10, sizeMultiplier: 1.3 },
-  sealed: { count: 0, sizeMultiplier: 0 },
+  completing: { count: 10, sizeMultiplier: 1.3 },
+  completed: { count: 0, sizeMultiplier: 0 },
 };
 
 const OVERBURN_GREY_PALETTE = [
@@ -253,18 +253,18 @@ export function smokeEffect(
   };
 }
 
-export function sealedSmokeEffect(
+export function completedSmokeEffect(
   wickY: number,
   wickX?: number,
-): SealedSmokeEffectConfig {
-  return { type: 'sealedSmoke', wickY, wickX };
+): CompletedSmokeEffectConfig {
+  return { type: 'completedSmoke', wickY, wickX };
 }
 
-export function simpleSealedSmokeEffect(
+export function simpleCompletedSmokeEffect(
   wickY: number,
-): SealedSmokeEffectConfig {
+): CompletedSmokeEffectConfig {
   return {
-    type: 'sealedSmoke',
+    type: 'completedSmoke',
     wickY,
     useFlameColor: true,
     riseHeight: 70,

--- a/app/(app)/flames/components/flame-card/effects/types.ts
+++ b/app/(app)/flames/components/flame-card/effects/types.ts
@@ -12,28 +12,28 @@ export interface FlameComponentProps {
   colors: ShapeColors;
 }
 
-export interface SealedFlameProps {
+export interface CompletedFlameProps {
   colors: ShapeColors;
 }
 
-export interface SealedSmokeEffectConfig {
-  type: 'sealedSmoke';
+export interface CompletedSmokeEffectConfig {
+  type: 'completedSmoke';
   wickY: number;
   wickX?: number;
   /** When true, uses the flame's medium color for the tendril instead of grey smoke */
   useFlameColor?: boolean;
-  /** Height of smoke column in SVG units — passed through to SealedSmokeWisps */
+  /** Height of smoke column in SVG units — passed through to CompletedSmokeWisps */
   riseHeight?: number;
-  /** When true, renders a single thin strand only — passed through to SealedSmokeWisps */
+  /** When true, renders a single thin strand only — passed through to CompletedSmokeWisps */
   simple?: boolean;
 }
 
-export type EffectConfig = FlameParticleEffect | SealedSmokeEffectConfig;
+export type EffectConfig = FlameParticleEffect | CompletedSmokeEffectConfig;
 
 export interface FlameDefinition {
   Flame: React.FC<FlameComponentProps>;
   Base?: React.FC;
-  SealedFlame?: React.FC<SealedFlameProps>;
+  CompletedFlame?: React.FC<CompletedFlameProps>;
 
   animation: {
     origin: { x: string; y: string };

--- a/app/(app)/flames/components/flame-card/flames/Bonfire.tsx
+++ b/app/(app)/flames/components/flame-card/flames/Bonfire.tsx
@@ -1,18 +1,18 @@
 import { motion } from 'framer-motion';
 import {
+  completedSmokeEffect,
   DANCING_EMBER_EFFECT,
   EMBER_EFFECT,
   FLICKER_DURATIONS,
   FLICKER_ORIGIN,
   FLICKER_VARIANTS,
   STANDARD_SMOKE_STATES,
-  sealedSmokeEffect,
   smokeEffect,
 } from '../effects/presets';
 import type {
+  CompletedFlameProps,
   FlameComponentProps,
   FlameDefinition,
-  SealedFlameProps,
 } from '../effects/types';
 
 function BonfireBase() {
@@ -88,7 +88,7 @@ function BonfireFlame({ colors }: FlameComponentProps) {
   );
 }
 
-function BonfireSealed({ colors }: SealedFlameProps) {
+function BonfireCompleted({ colors }: CompletedFlameProps) {
   return (
     <>
       <BonfireBase />
@@ -113,14 +113,14 @@ const smokeEffectStateConfig = {
   burning: { count: 15, sizeMultiplier: 2.5 },
   paused: { count: 8, sizeMultiplier: 1 },
   untended: { count: 2, sizeMultiplier: 1 },
-  sealing: { count: 15, sizeMultiplier: 2 },
-  sealed: { count: 0, sizeMultiplier: 0 },
+  completing: { count: 15, sizeMultiplier: 2 },
+  completed: { count: 0, sizeMultiplier: 0 },
 };
 
 export const Bonfire: FlameDefinition = {
   Base: BonfireBase,
   Flame: BonfireFlame,
-  SealedFlame: BonfireSealed,
+  CompletedFlame: BonfireCompleted,
   animation: {
     origin: FLICKER_ORIGIN,
     variants: FLICKER_VARIANTS,
@@ -130,6 +130,6 @@ export const Bonfire: FlameDefinition = {
     EMBER_EFFECT,
     DANCING_EMBER_EFFECT,
     smokeEffect(smokeEffectStateConfig),
-    sealedSmokeEffect(72),
+    completedSmokeEffect(72),
   ],
 };

--- a/app/(app)/flames/components/flame-card/flames/Candle.tsx
+++ b/app/(app)/flames/components/flame-card/flames/Candle.tsx
@@ -1,16 +1,16 @@
 import { motion, useReducedMotion } from 'framer-motion';
 import {
+  completedSmokeEffect,
   EMBER_EFFECT,
   FLICKER_DURATIONS,
   FLICKER_ORIGIN,
   FLICKER_VARIANTS,
-  sealedSmokeEffect,
   smokeEffect,
 } from '../effects/presets';
 import type {
+  CompletedFlameProps,
   FlameComponentProps,
   FlameDefinition,
-  SealedFlameProps,
 } from '../effects/types';
 
 function CandleBase() {
@@ -69,7 +69,7 @@ function WickSmolder({ color }: { color: string }) {
   );
 }
 
-function CandleSealed({ colors }: SealedFlameProps) {
+function CandleCompleted({ colors }: CompletedFlameProps) {
   return (
     <>
       <CandleBase />
@@ -108,7 +108,7 @@ const smokeEffectStateConfig = {
 export const Candle: FlameDefinition = {
   Base: CandleBase,
   Flame: CandleFlame,
-  SealedFlame: CandleSealed,
+  CompletedFlame: CandleCompleted,
   animation: {
     origin: FLICKER_ORIGIN,
     variants: FLICKER_VARIANTS,
@@ -117,6 +117,6 @@ export const Candle: FlameDefinition = {
   effects: [
     EMBER_EFFECT,
     smokeEffect(smokeEffectStateConfig),
-    sealedSmokeEffect(65),
+    completedSmokeEffect(65),
   ],
 };

--- a/app/(app)/flames/components/flame-card/flames/Star.tsx
+++ b/app/(app)/flames/components/flame-card/flames/Star.tsx
@@ -6,9 +6,9 @@ import {
   RADIATE_VARIANTS,
 } from '../effects/presets';
 import type {
+  CompletedFlameProps,
   FlameComponentProps,
   FlameDefinition,
-  SealedFlameProps,
 } from '../effects/types';
 
 function StarFlame({ colors }: FlameComponentProps) {
@@ -38,7 +38,7 @@ function StarFlame({ colors }: FlameComponentProps) {
   );
 }
 
-function StarSealed({ colors }: SealedFlameProps) {
+function StarCompleted({ colors }: CompletedFlameProps) {
   const shouldReduceMotion = useReducedMotion();
   return (
     <motion.g
@@ -60,7 +60,7 @@ function StarSealed({ colors }: SealedFlameProps) {
 
 export const Star: FlameDefinition = {
   Flame: StarFlame,
-  SealedFlame: StarSealed,
+  CompletedFlame: StarCompleted,
   animation: {
     origin: RADIATE_ORIGIN,
     variants: RADIATE_VARIANTS,

--- a/app/(app)/flames/components/flame-card/flames/Supernova.tsx
+++ b/app/(app)/flames/components/flame-card/flames/Supernova.tsx
@@ -6,9 +6,9 @@ import {
   RADIATE_VARIANTS,
 } from '../effects/presets';
 import type {
+  CompletedFlameProps,
   FlameComponentProps,
   FlameDefinition,
-  SealedFlameProps,
 } from '../effects/types';
 
 function SupernovaFlame({ colors }: FlameComponentProps) {
@@ -60,7 +60,7 @@ function SupernovaFlame({ colors }: FlameComponentProps) {
   );
 }
 
-function SupernovaSealed({ colors }: SealedFlameProps) {
+function SupernovaCompleted({ colors }: CompletedFlameProps) {
   const shouldReduceMotion = useReducedMotion();
   return (
     <motion.g
@@ -82,7 +82,7 @@ function SupernovaSealed({ colors }: SealedFlameProps) {
 
 export const Supernova: FlameDefinition = {
   Flame: SupernovaFlame,
-  SealedFlame: SupernovaSealed,
+  CompletedFlame: SupernovaCompleted,
   animation: {
     origin: RADIATE_ORIGIN,
     variants: RADIATE_VARIANTS,

--- a/app/(app)/flames/components/flame-card/flames/Torch.tsx
+++ b/app/(app)/flames/components/flame-card/flames/Torch.tsx
@@ -1,17 +1,17 @@
 import { motion } from 'framer-motion';
 import {
+  completedSmokeEffect,
   DANCING_EMBER_EFFECT,
   EMBER_EFFECT,
   FLICKER_DURATIONS,
   FLICKER_ORIGIN,
   FLICKER_VARIANTS,
-  sealedSmokeEffect,
   smokeEffect,
 } from '../effects/presets';
 import type {
+  CompletedFlameProps,
   FlameComponentProps,
   FlameDefinition,
-  SealedFlameProps,
 } from '../effects/types';
 
 function TorchBase() {
@@ -43,7 +43,7 @@ function TorchFlame({ colors }: FlameComponentProps) {
   );
 }
 
-function TorchSealed({ colors }: SealedFlameProps) {
+function TorchCompleted({ colors }: CompletedFlameProps) {
   return (
     <>
       <TorchBase />
@@ -66,7 +66,7 @@ function TorchSealed({ colors }: SealedFlameProps) {
 export const Torch: FlameDefinition = {
   Base: TorchBase,
   Flame: TorchFlame,
-  SealedFlame: TorchSealed,
+  CompletedFlame: TorchCompleted,
   animation: {
     origin: FLICKER_ORIGIN,
     variants: FLICKER_VARIANTS,
@@ -76,6 +76,6 @@ export const Torch: FlameDefinition = {
     EMBER_EFFECT,
     DANCING_EMBER_EFFECT,
     smokeEffect(),
-    sealedSmokeEffect(65),
+    completedSmokeEffect(65),
   ],
 };

--- a/app/(app)/flames/components/flame-card/flames/Wisp.tsx
+++ b/app/(app)/flames/components/flame-card/flames/Wisp.tsx
@@ -2,14 +2,14 @@ import {
   FLICKER_DURATIONS,
   FLICKER_ORIGIN,
   FLICKER_VARIANTS,
-  simpleSealedSmokeEffect,
+  simpleCompletedSmokeEffect,
   WISP_EMBER_EFFECT,
 } from '../effects/presets';
 import { SmolderingEmbers } from '../effects/SmolderingEmbers';
 import type {
+  CompletedFlameProps,
   FlameComponentProps,
   FlameDefinition,
-  SealedFlameProps,
 } from '../effects/types';
 
 function WispFlame({ colors }: FlameComponentProps) {
@@ -23,17 +23,17 @@ function WispFlame({ colors }: FlameComponentProps) {
   );
 }
 
-function WispSealed({ colors }: SealedFlameProps) {
+function WispCompleted({ colors }: CompletedFlameProps) {
   return <SmolderingEmbers color={colors.medium} />;
 }
 
 export const Wisp: FlameDefinition = {
   Flame: WispFlame,
-  SealedFlame: WispSealed,
+  CompletedFlame: WispCompleted,
   animation: {
     origin: FLICKER_ORIGIN,
     variants: FLICKER_VARIANTS,
     durations: FLICKER_DURATIONS,
   },
-  effects: [WISP_EMBER_EFFECT, simpleSealedSmokeEffect(62)],
+  effects: [WISP_EMBER_EFFECT, simpleCompletedSmokeEffect(62)],
 };

--- a/app/(app)/flames/components/hooks/useFlameState.ts
+++ b/app/(app)/flames/components/hooks/useFlameState.ts
@@ -26,10 +26,10 @@ interface UseFlameTimerReturn {
   isOverburning: boolean;
   toggle: () => Promise<void>;
   isLoading: boolean;
-  isSealReady: boolean;
-  beginSealing: () => void;
-  cancelSealing: () => void;
-  completeSeal: () => Promise<boolean>;
+  isCompletionReady: boolean;
+  beginCompletion: () => void;
+  cancelCompletion: () => void;
+  completeFlame: () => Promise<boolean>;
 }
 
 export function useFlameState({
@@ -54,14 +54,15 @@ export function useFlameState({
 
   const targetSeconds = (flame.time_budget_minutes ?? 0) * 60;
 
-  const sealThresholdSeconds =
-    'seal_threshold_minutes' in flame && flame.seal_threshold_minutes
-      ? (flame.seal_threshold_minutes as number) * 60
+  const completionThresholdSeconds =
+    'completion_threshold_minutes' in flame &&
+    flame.completion_threshold_minutes
+      ? (flame.completion_threshold_minutes as number) * 60
       : (flame.time_budget_minutes ?? 0) * 30; // 50% of budget as default
 
   const deriveState = useCallback((): FlameState => {
     if (!session) return 'untended';
-    if (session.is_completed) return 'sealed';
+    if (session.is_completed) return 'completed';
     if (session.started_at && !session.ended_at) return 'burning';
     if (session.ended_at) return 'paused';
     return 'untended';
@@ -89,14 +90,14 @@ export function useFlameState({
     return total;
   }, [session]);
 
-  // Update state when session changes, but don't override transient 'sealing' state
+  // Update state when session changes, but don't override transient 'completing' state
   useEffect(() => {
     // Fresh session data arrived — clear optimistic fallback so
     // calculateElapsed uses the real server timestamps from now on.
     optimisticStartRef.current = null;
 
     setState((prev) => {
-      if (prev === 'sealing') return prev;
+      if (prev === 'completing') return prev;
       return deriveState();
     });
     setLocalElapsed(calculateElapsed());
@@ -229,8 +230,8 @@ export function useFlameState({
           break;
         }
 
-        case 'sealed':
-        case 'sealing':
+        case 'completed':
+        case 'completing':
           // No action
           break;
       }
@@ -243,26 +244,26 @@ export function useFlameState({
     }
   };
 
-  const isSealReady =
+  const isCompletionReady =
     state === 'paused' &&
-    sealThresholdSeconds > 0 &&
-    localElapsed >= sealThresholdSeconds;
+    completionThresholdSeconds > 0 &&
+    localElapsed >= completionThresholdSeconds;
 
-  const beginSealing = () => {
-    if (isSealReady) {
-      setState('sealing');
+  const beginCompletion = () => {
+    if (isCompletionReady) {
+      setState('completing');
     }
   };
 
-  const cancelSealing = () => {
-    if (state === 'sealing') {
+  const cancelCompletion = () => {
+    if (state === 'completing') {
       setState('paused');
     }
   };
 
-  const completeSeal = async (): Promise<boolean> => {
-    // Optimistically transition to sealed state so visual effects fire immediately
-    setState('sealed');
+  const completeFlame = async (): Promise<boolean> => {
+    // Optimistically transition to completed state so visual effects fire immediately
+    setState('completed');
     try {
       const result = await setFlameCompletion(flame.id, date, true);
       if (result.success) {
@@ -291,9 +292,9 @@ export function useFlameState({
     isOverburning,
     toggle,
     isLoading,
-    isSealReady,
-    beginSealing,
-    cancelSealing,
-    completeSeal,
+    isCompletionReady,
+    beginCompletion,
+    cancelCompletion,
+    completeFlame,
   };
 }

--- a/app/(app)/flames/components/particles/FlameParticles.tsx
+++ b/app/(app)/flames/components/particles/FlameParticles.tsx
@@ -57,11 +57,12 @@ export function FlameParticles({
   const activeModifiers = useMemo(
     () =>
       modifiers?.filter((m) => {
-        if (m.condition === 'sealReady') return conditions.sealReady;
+        if (m.condition === 'completionReady')
+          return conditions.completionReady;
         if (m.condition === 'overburning') return conditions.overburning;
         return false;
       }) ?? [],
-    [modifiers, conditions.sealReady, conditions.overburning],
+    [modifiers, conditions.completionReady, conditions.overburning],
   );
 
   // Merge state config with modifier overrides
@@ -96,11 +97,11 @@ export function FlameParticles({
   }, [activeModifiers]);
 
   // Visibility
-  const sealedCount = effectiveStateConfig.sealed?.count ?? 0;
+  const completedCount = effectiveStateConfig.completed?.count ?? 0;
   const customVisible = showWhen ? showWhen(state) : false;
   const active =
     shouldShowParticles(state) ||
-    (state === 'sealed' && sealedCount > 0) ||
+    (state === 'completed' && completedCount > 0) ||
     customVisible;
 
   const idCounter = useRef(0);

--- a/app/(app)/flames/components/particles/types.ts
+++ b/app/(app)/flames/components/particles/types.ts
@@ -26,8 +26,8 @@ export interface ParticleStateConfig {
   burning: { count: number; sizeMultiplier: number };
   paused: { count: number; sizeMultiplier: number };
   untended: { count: number; sizeMultiplier: number };
-  sealing?: { count: number; sizeMultiplier: number };
-  sealed?: { count: number; sizeMultiplier: number };
+  completing?: { count: number; sizeMultiplier: number };
+  completed?: { count: number; sizeMultiplier: number };
 }
 
 export interface AnimationIntensity {
@@ -47,7 +47,7 @@ export interface BaseParticleProps {
 export type PaletteFn = (colors: ShapeColors) => readonly string[];
 
 export interface StateModifier {
-  condition: 'sealReady' | 'overburning';
+  condition: 'completionReady' | 'overburning';
   palette?: PaletteFn | readonly string[];
   stateOverrides?: Partial<ParticleStateConfig>;
   speedMultiplier?: number;
@@ -82,6 +82,6 @@ export interface FlameParticleEffect {
 }
 
 export interface ParticleConditions {
-  sealReady: boolean;
+  completionReady: boolean;
   overburning: boolean;
 }

--- a/app/(app)/flames/components/particles/utils.ts
+++ b/app/(app)/flames/components/particles/utils.ts
@@ -99,8 +99,8 @@ export function getParticleIntensity(
       };
     case 'untended':
     case 'paused':
-    case 'sealed':
-    case 'sealing':
+    case 'completed':
+    case 'completing':
       return {
         opacity: config?.inactiveOpacity ?? 0.4,
         speed: config?.inactiveSpeed ?? 1,
@@ -113,6 +113,6 @@ export function shouldShowParticles(state: FlameState): boolean {
     state === 'burning' ||
     state === 'paused' ||
     state === 'untended' ||
-    state === 'sealing'
+    state === 'completing'
   );
 }

--- a/app/(app)/flames/schedule/page.tsx
+++ b/app/(app)/flames/schedule/page.tsx
@@ -2,8 +2,8 @@ import { ChevronLeftIcon } from 'lucide-react';
 import Link from 'next/link';
 import { getTranslations } from 'next-intl/server';
 import { getServerToday } from '@/lib/timezone';
-import { getWeeklySchedule } from './queries';
 import { WeeklyPlanner } from './components/WeeklyPlanner';
+import { getWeeklySchedule } from './queries';
 
 export default async function SchedulePage() {
   const t = await getTranslations('schedule');

--- a/app/(app)/flames/utils/types.ts
+++ b/app/(app)/flames/utils/types.ts
@@ -2,5 +2,5 @@ export type FlameState =
   | 'untended'
   | 'burning'
   | 'paused'
-  | 'sealing'
-  | 'sealed';
+  | 'completing'
+  | 'completed';

--- a/app/(app)/shop/actions.ts
+++ b/app/(app)/shop/actions.ts
@@ -68,11 +68,11 @@ export async function getUserInventory(): ActionResult<
 }
 
 /**
- * Credits sparks to the user for sealing a flame session.
+ * Credits sparks to the user for completing a flame session.
  * Idempotent: if the session was already credited, returns { sparks: 0 }.
  * Uses an atomic RPC to prevent race conditions on double-credit and balance update.
  */
-export async function creditSealReward(
+export async function creditCompletionReward(
   flameId: string,
   date: string,
 ): ActionResult<{ sparks: number }> {
@@ -112,7 +112,7 @@ export async function creditSealReward(
 
   // Atomic: insert transaction (idempotent) + increment balance
   const { data: credited, error: rpcError } = await supabase.rpc(
-    'credit_seal_sparks',
+    'credit_completion_sparks',
     {
       p_user_id: user.id,
       p_session_id: session.id,
@@ -124,7 +124,7 @@ export async function creditSealReward(
     return { success: false, error: rpcError };
   }
 
-  // No revalidatePath here — the seal completion action already revalidates
+  // No revalidatePath here — the completion action already revalidates
   // /flames, and premature revalidation would update the profile badge before
   // the flyover animation finishes.
 

--- a/app/globals.css
+++ b/app/globals.css
@@ -5,7 +5,7 @@
 @custom-variant dark (&:is(.dark *));
 
 @theme inline {
-  --animate-seal-ready-glow: seal-ready-glow 2.5s ease-in-out infinite;
+  --animate-completion-ready-glow: completion-ready-glow 2.5s ease-in-out infinite;
   --color-background: var(--background);
   --color-foreground: var(--foreground);
   --font-sans: var(--font-latin), var(--font-ja);
@@ -126,7 +126,7 @@
   }
 }
 
-@keyframes seal-ready-glow {
+@keyframes completion-ready-glow {
   0%,
   100% {
     box-shadow: 0 0 8px #fbbf2435, 0 0 16px #fbbf2420;
@@ -137,7 +137,7 @@
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .animate-seal-ready-glow {
+  .animate-completion-ready-glow {
     animation: none;
     box-shadow: 0 0 15px #fbbf2450, 0 0 30px #fbbf2425;
   }

--- a/lib/sparks.ts
+++ b/lib/sparks.ts
@@ -5,8 +5,8 @@ export const OVERBURN_GRACE = 1.05;
 
 /**
  * Shared spark reward calculation — single source of truth for
- * both the frontend preview (SealSummaryModal) and the backend ledger
- * (creditSealReward server action).
+ * both the frontend preview (CompletionSummaryModal) and the backend ledger
+ * (creditCompletionReward server action).
  */
 export function calculateSparks(
   elapsedSeconds: number,

--- a/messages/en.json
+++ b/messages/en.json
@@ -107,16 +107,16 @@
       "tended": "Tended",
       "blocked": "Idle",
       "noFuel": "No fuel",
-      "sealing": "Sealing ...",
-      "sealed": "Sealed",
-      "readyToSeal": "Ready to Seal",
+      "completing": "Completing ...",
+      "completed": "Completed",
+      "readyToComplete": "Ready to Complete",
       "overburning": "Overburn",
       "pauseError": "Failed to pause Flame timer — please try again",
       "startError": "Failed to start Flame timer — please try again",
       "resumeError": "Failed to resume Flame timer — please try again"
     },
-    "seal": {
-      "title": "Flame Sealed!",
+    "completion": {
+      "title": "Flame Completed!",
       "subtitlesOverburn": [
         "Your passion burns hot, but be careful not to burn out.",
         "Impressive heat — just remember to save fuel for tomorrow.",
@@ -142,7 +142,7 @@
       "xpEarned": "Heat Earned",
       "minutes": "{count} min",
       "dismiss": "Keep it up!",
-      "error": "Failed to seal flame. Please try again."
+      "error": "Failed to complete flame. Please try again."
     },
     "todayTitle": "Today's Flames",
     "scheduleLink": "Weekly schedule",

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -107,16 +107,16 @@
       "tended": "Tended",
       "blocked": "Idle",
       "noFuel": "No fuel",
-      "sealing": "封印中 ...",
-      "sealed": "封印済み",
-      "readyToSeal": "封印可能",
+      "completing": "達成中 ...",
+      "completed": "達成済み",
+      "readyToComplete": "達成可能",
       "overburning": "超過燃焼",
       "pauseError": "炎タイマーの一時停止に失敗しました。もう一度お試しください",
       "startError": "炎タイマーの開始に失敗しました。もう一度お試しください",
       "resumeError": "炎タイマーの再開に失敗しました。もう一度お試しください"
     },
-    "seal": {
-      "title": "炎を封印しました！",
+    "completion": {
+      "title": "炎を達成しました！",
       "subtitlesOverburn": [
         "情熱の炎は熱い。でも燃え尽きないように。",
         "すごい熱量 — 明日の分の燃料も残しておこう。",
@@ -142,7 +142,7 @@
       "xpEarned": "獲得ヒート",
       "minutes": "{count}分",
       "dismiss": "この調子で！",
-      "error": "封印に失敗しました。もう一度お試しください。"
+      "error": "達成に失敗しました。もう一度お試しください。"
     },
     "todayTitle": "今日のフレイム",
     "scheduleLink": "週間スケジュール",

--- a/supabase/migrations/20260223000000_rename_seal_to_completion.sql
+++ b/supabase/migrations/20260223000000_rename_seal_to_completion.sql
@@ -1,0 +1,70 @@
+-- Rename "seal" terminology to "completion" across columns, RPCs, and data.
+
+-- 1. Rename column: flames.seal_threshold_minutes → completion_threshold_minutes
+alter table public.flames
+  rename column seal_threshold_minutes to completion_threshold_minutes;
+
+-- 2. Update existing spark transaction reasons: 'seal' → 'completion'
+update public.spark_transactions
+set reason = 'completion'
+where reason = 'seal';
+
+-- 3. Recreate RPC with new name: credit_completion_sparks
+--    (uses 'completion' as the transaction reason)
+create or replace function public.credit_completion_sparks(
+  p_user_id uuid,
+  p_session_id uuid,
+  p_amount integer
+)
+returns integer
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+begin
+  -- Guard: caller must be the target user, and amount must be positive
+  if auth.uid() is null or auth.uid() <> p_user_id or p_amount <= 0 then
+    return 0;
+  end if;
+
+  -- Guard: session must belong to the caller (direct column check)
+  if not exists (
+    select 1
+    from public.flame_sessions fs
+    where fs.id = p_session_id
+      and fs.user_id = auth.uid()
+  ) then
+    return 0;
+  end if;
+
+  -- Attempt insert; ON CONFLICT means already credited
+  insert into public.spark_transactions (user_id, amount, reason, reference_id)
+  values (p_user_id, p_amount, 'completion', p_session_id)
+  on conflict (reference_id, reason) do nothing;
+
+  -- FOUND is true if the INSERT affected a row, false if ON CONFLICT skipped it
+  if not found then
+    return 0;
+  end if;
+
+  -- Atomic balance increment
+  update public.user_state
+  set sparks_balance = sparks_balance + p_amount,
+      updated_at = now()
+  where user_id = p_user_id;
+
+  -- If no row existed yet, create one
+  if not found then
+    insert into public.user_state (user_id, sparks_balance)
+    values (p_user_id, p_amount)
+    on conflict (user_id) do update
+    set sparks_balance = user_state.sparks_balance + p_amount,
+        updated_at = now();
+  end if;
+
+  return p_amount;
+end;
+$$;
+
+-- 4. Drop the old RPC
+drop function if exists public.credit_seal_sparks(uuid, uuid, integer);

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -27,7 +27,7 @@
 
   -- Sample spark transactions (earn, earn, spend)
   insert into spark_transactions (user_id, amount, reason) values
-    ('11111111-1111-1111-1111-111111111111', 100, 'seal'),
+    ('11111111-1111-1111-1111-111111111111', 100, 'completion'),
     ('11111111-1111-1111-1111-111111111111', 100, 'streak_bonus'),
     ('11111111-1111-1111-1111-111111111111', -50, 'purchase');
     

--- a/utils/supabase/types.ts
+++ b/utils/supabase/types.ts
@@ -108,6 +108,7 @@ export type Database = {
       flames: {
         Row: {
           color: string | null;
+          completion_threshold_minutes: number | null;
           count_target: number | null;
           count_unit: string | null;
           created_at: string;
@@ -115,7 +116,6 @@ export type Database = {
           id: string;
           is_archived: boolean;
           name: string;
-          seal_threshold_minutes: number | null;
           time_budget_minutes: number | null;
           tracking_type: string;
           updated_at: string;
@@ -123,6 +123,7 @@ export type Database = {
         };
         Insert: {
           color?: string | null;
+          completion_threshold_minutes?: number | null;
           count_target?: number | null;
           count_unit?: string | null;
           created_at?: string;
@@ -130,7 +131,6 @@ export type Database = {
           id?: string;
           is_archived?: boolean;
           name: string;
-          seal_threshold_minutes?: number | null;
           time_budget_minutes?: number | null;
           tracking_type: string;
           updated_at?: string;
@@ -138,6 +138,7 @@ export type Database = {
         };
         Update: {
           color?: string | null;
+          completion_threshold_minutes?: number | null;
           count_target?: number | null;
           count_unit?: string | null;
           created_at?: string;
@@ -145,7 +146,6 @@ export type Database = {
           id?: string;
           is_archived?: boolean;
           name?: string;
-          seal_threshold_minutes?: number | null;
           time_budget_minutes?: number | null;
           tracking_type?: string;
           updated_at?: string;
@@ -432,7 +432,7 @@ export type Database = {
       [_ in never]: never;
     };
     Functions: {
-      credit_seal_sparks: {
+      credit_completion_sparks: {
         Args: { p_amount: number; p_session_id: string; p_user_id: string };
         Returns: number;
       };


### PR DESCRIPTION
This nomenclature was kinda bad and not intuitive. Let's just call it completion instead. Updates it in all parts of the codebase and copy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated terminology throughout the flame interaction system from "seal" to "complete," including state names, UI labels, and user-facing text in English and Japanese translations.
  * Renamed internal components and functions to align with the new completion naming convention.

* **Documentation**
  * Updated UI strings and translation messages to reflect the completion workflow, including updated status labels and error messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->