### PR TITLE
fix(fnf): Flames page loading state layout shift

### DIFF
--- a/app/(app)/flames/components/FlamesList.tsx
+++ b/app/(app)/flames/components/FlamesList.tsx
@@ -6,6 +6,7 @@ import type { Flame, FlameSession } from '@/utils/supabase/rows';
 import type { FuelBudgetStatus } from '../actions';
 import { FlamesProvider, useFlamesContext } from '../hooks/useFlames';
 import { FlamesPageActions } from './FlamesPageActions';
+import { FuelBarStickyContainer } from './FuelBarStickyContainer';
 import { FuelMeter } from './FuelMeter';
 import { InteractiveFlameCard } from './flame-card/InteractiveFlameCard';
 
@@ -57,7 +58,7 @@ function FlamesListContent() {
   return (
     <div>
       <div ref={sentinelRef} className="h-0" />
-      <div className="sticky top-12 z-20 -mx-4 mb-4 px-4 pt-2 md:top-14">
+      <FuelBarStickyContainer>
         <div className="flex items-stretch gap-2">
           <div className="min-w-0 flex-1">
             <FuelMeter
@@ -77,7 +78,7 @@ function FlamesListContent() {
             <FlamesPageActions />
           </div>
         </div>
-      </div>
+      </FuelBarStickyContainer>
       <div className="grid grid-cols-2 gap-3 sm:gap-4 md:grid-cols-3 lg:grid-cols-4">
         {entries.map((entry) => (
           <InteractiveFlameCard

--- a/app/(app)/flames/components/FuelBarStickyContainer.tsx
+++ b/app/(app)/flames/components/FuelBarStickyContainer.tsx
@@ -1,0 +1,22 @@
+import { cn } from '@/lib/utils';
+
+interface FuelBarStickyContainerProps {
+  children: React.ReactNode;
+  className?: string;
+}
+
+export function FuelBarStickyContainer({
+  children,
+  className,
+}: FuelBarStickyContainerProps) {
+  return (
+    <div
+      className={cn(
+        'sticky top-12 z-20 -mx-4 mb-4 px-4 pt-2 md:top-14',
+        className,
+      )}
+    >
+      {children}
+    </div>
+  );
+}

--- a/app/(app)/flames/components/flame-card/FlameCardSkeleton.tsx
+++ b/app/(app)/flames/components/flame-card/FlameCardSkeleton.tsx
@@ -1,4 +1,5 @@
 import { Fuel } from 'lucide-react';
+import { FuelBarStickyContainer } from '../FuelBarStickyContainer';
 
 export function FlameCardSkeleton() {
   return (
@@ -52,7 +53,7 @@ export function FlameCardSkeleton() {
 
 export function FuelMeterSkeleton({ label }: { label: string }) {
   return (
-    <div className="sticky top-0 z-20 -mx-4 mb-4 bg-background/80 px-4 pb-0 backdrop-blur-sm">
+    <FuelBarStickyContainer className="bg-background/80 backdrop-blur-sm">
       <div className="rounded-lg border border-border bg-card px-3 py-2.5">
         <div className="flex items-center gap-2.5">
           {/* Icon + label — static, no skeleton needed */}
@@ -68,6 +69,6 @@ export function FuelMeterSkeleton({ label }: { label: string }) {
           <div className="h-3 w-14 shrink-0 animate-pulse rounded bg-muted" />
         </div>
       </div>
-    </div>
+    </FuelBarStickyContainer>
   );
 }


### PR DESCRIPTION
- Fixed annoying layout shift during page load transition of Flames page
- Extract `FuelBarStickyContainer` for sticky and sizing logic shared between actual fuel bar and loading skeleton version

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Extracted sticky header container functionality into a reusable component for improved code organization and maintainability across the flames section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->