### PR TITLE
polish: Redesign auth pages with branding and modern layout

### DIFF
--- a/app/(auth)/layout.tsx
+++ b/app/(auth)/layout.tsx
@@ -1,0 +1,15 @@
+import type { ReactNode } from 'react';
+
+export default function AuthLayout({ children }: { children: ReactNode }) {
+  return (
+    <div className="relative flex min-h-svh flex-col items-center justify-center bg-background p-6 md:p-10">
+      <div
+        aria-hidden
+        className="pointer-events-none fixed inset-0 overflow-hidden"
+      >
+        <div className="absolute -top-40 left-1/2 h-[500px] w-[800px] -translate-x-1/2 rounded-full bg-primary/[0.07] blur-[100px]" />
+      </div>
+      <div className="relative z-10 w-full max-w-sm">{children}</div>
+    </div>
+  );
+}

--- a/app/(auth)/login/form.tsx
+++ b/app/(auth)/login/form.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { zodResolver } from '@hookform/resolvers/zod';
+import Link from 'next/link';
 import { useTranslations } from 'next-intl';
 import { useMemo, useState } from 'react';
 import { Controller, useForm } from 'react-hook-form';
@@ -86,7 +87,7 @@ export function LoginForm() {
   }
 
   return (
-    <Card>
+    <Card className="w-full">
       <CardHeader>
         <CardTitle>{t('title')}</CardTitle>
         <CardDescription>{t('description')}</CardDescription>
@@ -165,7 +166,8 @@ export function LoginForm() {
               </Field>
 
               <FieldDescription className="px-6 text-center">
-                {t('noAccount')} <a href="/signup">{t('signUpLink')}</a>
+                {t('noAccount')}{' '}
+                <Link href="/signup">{t('signUpLink')}</Link>
               </FieldDescription>
             </FieldGroup>
           </FieldGroup>

--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -1,11 +1,21 @@
+import Image from 'next/image';
+import Link from 'next/link';
+import { getTranslations } from 'next-intl/server';
 import { LoginForm } from './form';
 
-export default function LoginPage() {
+export default async function LoginPage() {
+  const t = await getTranslations('metadata');
+
   return (
-    <div className="flex min-h-svh w-full items-center justify-center p-6 md:p-10">
-      <div className="w-full max-w-sm">
-        <LoginForm />
-      </div>
+    <div className="flex flex-col items-center gap-8">
+      <Link href="/" className="flex flex-col items-center gap-3">
+        <Image src="/logo.svg" alt="" width={48} height={48} />
+        <div className="flex flex-col items-center gap-1">
+          <h1 className="text-2xl font-extrabold tracking-tight">Hibana</h1>
+          <p className="text-sm text-muted-foreground">{t('description')}</p>
+        </div>
+      </Link>
+      <LoginForm />
     </div>
   );
 }

--- a/app/(auth)/signup/form.tsx
+++ b/app/(auth)/signup/form.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { zodResolver } from '@hookform/resolvers/zod';
+import Link from 'next/link';
 import { useTranslations } from 'next-intl';
 import { useMemo, useState } from 'react';
 import { Controller, useForm } from 'react-hook-form';
@@ -108,7 +109,7 @@ export function SignupForm() {
   }
 
   return (
-    <Card>
+    <Card className="w-full">
       <CardHeader>
         <CardTitle>{t('title')}</CardTitle>
         <CardDescription>{t('description')}</CardDescription>
@@ -209,7 +210,8 @@ export function SignupForm() {
               </Field>
 
               <FieldDescription className="px-6 text-center">
-                {t('hasAccount')} <a href="/login">{t('loginLink')}</a>
+                {t('hasAccount')}{' '}
+                <Link href="/login">{t('loginLink')}</Link>
               </FieldDescription>
             </FieldGroup>
           </FieldGroup>

--- a/app/(auth)/signup/page.tsx
+++ b/app/(auth)/signup/page.tsx
@@ -1,11 +1,21 @@
+import Image from 'next/image';
+import Link from 'next/link';
+import { getTranslations } from 'next-intl/server';
 import { SignupForm } from './form';
 
-export default function SignupPage() {
+export default async function SignupPage() {
+  const t = await getTranslations('metadata');
+
   return (
-    <div className="flex min-h-svh w-full items-center justify-center p-6 md:p-10">
-      <div className="w-full max-w-sm">
-        <SignupForm />
-      </div>
+    <div className="flex flex-col items-center gap-8">
+      <Link href="/" className="flex flex-col items-center gap-3">
+        <Image src="/logo.svg" alt="" width={48} height={48} />
+        <div className="flex flex-col items-center gap-1">
+          <h1 className="text-2xl font-extrabold tracking-tight">Hibana</h1>
+          <p className="text-sm text-muted-foreground">{t('description')}</p>
+        </div>
+      </Link>
+      <SignupForm />
     </div>
   );
 }


### PR DESCRIPTION
Add shared auth layout with subtle warm gradient background, Hibana logo and wordmark above form cards, and proper Next.js Link navigation between login/signup pages.

https://claude.ai/code/session_014935zfPjbUQ9NTETzZqr68

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added header with logo and title to authentication pages (login and signup).
  * Displayed description text on authentication pages.
  * Improved navigation links across authentication pages.
  * Enhanced page layouts with full-width styling for better visual presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->