### PR TITLE
fix: Allow scrolling on completable flame cards on mobile

### DIFF
--- a/app/(app)/flames/components/flame-card/FlameCard.tsx
+++ b/app/(app)/flames/components/flame-card/FlameCard.tsx
@@ -267,10 +267,7 @@ export function FlameCard({
     isDimmed && 'opacity-40',
   );
 
-  const cardStyle = {
-    ...borderGlowStyle,
-    ...(canComplete ? { touchAction: 'none' as const } : {}),
-  };
+  const cardStyle = borderGlowStyle;
 
   return (
     <div ref={cardRef} className={cn('relative', sizeConfig.card)}>

--- a/app/(app)/flames/hooks/useLongPress.ts
+++ b/app/(app)/flames/hooks/useLongPress.ts
@@ -2,6 +2,9 @@
 
 import { useCallback, useEffect, useRef, useState } from 'react';
 
+/** Max distance (px) a finger can move before a long press is canceled */
+const MOVE_THRESHOLD = 10;
+
 interface UseLongPressOptions {
   duration: number;
   onComplete: () => void;
@@ -16,6 +19,7 @@ interface UseLongPressReturn {
   longPressTriggered: boolean;
   handlers: {
     onPointerDown: (e: React.PointerEvent) => void;
+    onPointerMove: (e: React.PointerEvent) => void;
     onPointerUp: () => void;
     onPointerLeave: () => void;
     onPointerCancel: () => void;
@@ -35,6 +39,9 @@ export function useLongPress({
   const [progress, setProgress] = useState(0);
   const [isPressed, setIsPressed] = useState(false);
   const longPressTriggeredRef = useRef(false);
+
+  // Track pointer start position for movement detection
+  const startPosRef = useRef<{ x: number; y: number } | null>(null);
 
   // Store latest callbacks in refs to avoid stale closures in rAF loop
   const onProgressRef = useRef(onProgress);
@@ -57,6 +64,7 @@ export function useLongPress({
       rafRef.current = null;
     }
     startTimeRef.current = null;
+    startPosRef.current = null;
   }, []);
 
   const tick = useCallback(() => {
@@ -78,23 +86,6 @@ export function useLongPress({
     rafRef.current = requestAnimationFrame(tick);
   }, [duration]);
 
-  const handlePointerDown = useCallback(
-    (e: React.PointerEvent) => {
-      if (!enabled) return;
-      if (e.button !== 0) return;
-
-      startTimeRef.current = Date.now();
-      setIsPressed(true);
-      completedRef.current = false;
-      longPressTriggeredRef.current = false;
-      setProgress(0);
-      onProgressRef.current?.(0);
-
-      rafRef.current = requestAnimationFrame(tick);
-    },
-    [enabled, tick],
-  );
-
   const handleRelease = useCallback(() => {
     if (!startTimeRef.current) return;
     const wasCompleted = completedRef.current;
@@ -108,12 +99,44 @@ export function useLongPress({
     }
   }, [cleanup, progress]);
 
+  const handlePointerDown = useCallback(
+    (e: React.PointerEvent) => {
+      if (!enabled) return;
+      if (e.button !== 0) return;
+
+      startPosRef.current = { x: e.clientX, y: e.clientY };
+      startTimeRef.current = Date.now();
+      setIsPressed(true);
+      completedRef.current = false;
+      longPressTriggeredRef.current = false;
+      setProgress(0);
+      onProgressRef.current?.(0);
+
+      rafRef.current = requestAnimationFrame(tick);
+    },
+    [enabled, tick],
+  );
+
+  const handlePointerMove = useCallback(
+    (e: React.PointerEvent) => {
+      if (!startPosRef.current || !startTimeRef.current) return;
+
+      const dx = e.clientX - startPosRef.current.x;
+      const dy = e.clientY - startPosRef.current.y;
+      if (dx * dx + dy * dy > MOVE_THRESHOLD * MOVE_THRESHOLD) {
+        handleRelease();
+      }
+    },
+    [handleRelease],
+  );
+
   return {
     progress,
     isPressed,
     longPressTriggered: longPressTriggeredRef.current,
     handlers: {
       onPointerDown: handlePointerDown,
+      onPointerMove: handlePointerMove,
       onPointerUp: handleRelease,
       onPointerLeave: handleRelease,
       onPointerCancel: handleRelease,


### PR DESCRIPTION
Remove `touchAction: 'none'` from completable flame cards and add pointer movement detection to `useLongPress`. When a finger moves more than 10px from its start position, the long press is canceled, allowing the browser to handle scrolling naturally. Holding still continues to trigger the completion long press as before.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Touch interactions on flame cards now respond normally without restrictions.
  * Long-press detection now cancels when pointer movement exceeds a small threshold, reducing accidental activations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->