### PR TITLE
fix(fnf): Flame Completion modal not showing sparks on close

### DIFF
--- a/app/(app)/flames/components/CompletionSummaryModal.tsx
+++ b/app/(app)/flames/components/CompletionSummaryModal.tsx
@@ -329,19 +329,24 @@ export function CompletionSummaryModal({
   const sparksCount = useCountUp(rewards.sparks, showStats);
   const xpCount = useCountUp(rewards.xp, showStats);
 
-  const handleDismiss = useCallback(() => {
-    // Launch spark flyover from the spark count to the profile badge
-    if (sparksRef.current && rewards.sparks > 0) {
-      const rect = sparksRef.current.getBoundingClientRect();
-      triggerFlyover(rect, rewards.sparks);
-    }
-    onOpenChange(false);
-  }, [onOpenChange, triggerFlyover, rewards.sparks]);
+  const handleClose = useCallback(
+    (nextOpen: boolean) => {
+      if (!nextOpen) {
+        // Launch spark flyover from the spark count to the profile badge
+        if (sparksRef.current && rewards.sparks > 0) {
+          const rect = sparksRef.current.getBoundingClientRect();
+          triggerFlyover(rect, rewards.sparks);
+        }
+      }
+      onOpenChange(nextOpen);
+    },
+    [onOpenChange, triggerFlyover, rewards.sparks],
+  );
 
   const titleGradient = `linear-gradient(to right, ${colors.dark}, ${colors.medium}, ${colors.light})`;
 
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
+    <Dialog open={open} onOpenChange={handleClose}>
       <DialogContent
         showCloseButton={false}
         className="overflow-visible border bg-card text-card-foreground"
@@ -489,7 +494,7 @@ export function CompletionSummaryModal({
 
         <DialogFooter>
           <Button
-            onClick={handleDismiss}
+            onClick={() => handleClose(false)}
             className="w-full text-white hover:brightness-110"
             style={{ backgroundColor: colors.medium }}
           >


### PR DESCRIPTION
Fixes #178 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Improved the spark flyover behavior in the completion summary modal. The notification now appears only when closing the modal, eliminating unexpected triggers and providing a cleaner user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->