### PR TITLE
chore(tooling): Create pre-commit and pre-push git hooks

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,2 +1,1 @@
-pnpx biome check --write --unsafe --no-errors-on-unmatched --staged
-
+pnpm precommit

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,94 @@
-pnpm precommit
+#!/bin/sh
+
+# ─── Colors & Formatting ────────────────────────────────
+BOLD='\033[1m'
+DIM='\033[2m'
+RESET='\033[0m'
+RED='\033[31m'
+GREEN='\033[32m'
+YELLOW='\033[33m'
+CYAN='\033[36m'
+
+# ─── Header ──────────────────────────────────────────────
+printf "\n"
+printf "  %b🔥 hibana%b %bpre-commit%b\n" "$BOLD" "$RESET" "$DIM" "$RESET"
+printf "  %b━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━%b\n\n" "$DIM" "$RESET"
+
+# ─── Collect staged files ────────────────────────────────
+STAGED=$(git diff --cached --name-only --diff-filter=ACMR)
+
+if [ -z "$STAGED" ]; then
+  printf "  %bno files to check%b\n\n" "$DIM" "$RESET"
+  exit 0
+fi
+
+FILE_COUNT=$(printf "%s\n" "$STAGED" | wc -l | tr -d ' ')
+printf "  %b▸%b %b%s%b file(s) staged\n" "$CYAN" "$RESET" "$BOLD" "$FILE_COUNT" "$RESET"
+printf "%s\n" "$STAGED" | while IFS= read -r f; do
+  printf "    %b%s%b\n" "$DIM" "$f" "$RESET"
+done
+
+# ─── Run Biome ───────────────────────────────────────────
+printf "\n  %b▸%b running biome check\n" "$CYAN" "$RESET"
+
+if OUTPUT=$(pnpm precommit 2>&1); then
+  STATUS=0
+else
+  STATUS=$?
+fi
+
+# Strip pnpm script header noise, keep only biome output
+OUTPUT=$(printf "%s\n" "$OUTPUT" | grep -v "^>" | grep -v "^$" | sed 's/^ *//')
+
+if [ $STATUS -ne 0 ]; then
+  printf "\n"
+  printf "%s\n" "$OUTPUT" | while IFS= read -r line; do
+    printf "    %s\n" "$line"
+  done
+  printf "\n  %b✗ pre-commit failed%b %b— fix errors above and retry%b\n\n" "$RED" "$RESET" "$DIM" "$RESET"
+  exit $STATUS
+fi
+
+printf "    %b%s%b\n" "$DIM" "$OUTPUT" "$RESET"
+
+# ─── Detect auto-fixed files ────────────────────────────
+CHANGED=$(printf "%s\n" "$STAGED" | tr '\n' '\0' | xargs -0 git diff --name-only -- 2>/dev/null) || true
+
+if [ -n "$CHANGED" ]; then
+  CHANGED_COUNT=$(printf "%s\n" "$CHANGED" | wc -l | tr -d ' ')
+  printf "\n  %b✏%b  %b%s%b file(s) auto-fixed:\n\n" "$YELLOW" "$RESET" "$BOLD" "$CHANGED_COUNT" "$RESET"
+
+  # Compact stat summary
+  printf "%s\n" "$CHANGED" | tr '\n' '\0' | xargs -0 git diff --stat --color=always -- | while IFS= read -r line; do
+    printf "    %s\n" "$line"
+  done
+
+  # Diff detail
+  DIFF_LINES=$(printf "%s\n" "$CHANGED" | tr '\n' '\0' | xargs -0 git diff -- | wc -l | tr -d ' ')
+
+  if [ "$DIFF_LINES" -gt 0 ]; then
+    printf "\n  %b┌─ diff ─────────────────────────────%b\n" "$DIM" "$RESET"
+
+    if [ "$DIFF_LINES" -le 80 ]; then
+      printf "%s\n" "$CHANGED" | tr '\n' '\0' | xargs -0 git diff --color=always -- | while IFS= read -r line; do
+        printf "  %b│%b %s\n" "$DIM" "$RESET" "$line"
+      done
+    else
+      printf "%s\n" "$CHANGED" | tr '\n' '\0' | xargs -0 git diff --color=always -- | head -80 | while IFS= read -r line; do
+        printf "  %b│%b %s\n" "$DIM" "$RESET" "$line"
+      done
+      REMAINING=$((DIFF_LINES - 80))
+      printf "  %b│%b %b… %s more lines%b\n" "$DIM" "$RESET" "$DIM" "$REMAINING" "$RESET"
+    fi
+
+    printf "  %b└────────────────────────────────────%b\n" "$DIM" "$RESET"
+  fi
+
+  # Re-stage the fixed files
+  printf "%s\n" "$CHANGED" | tr '\n' '\0' | xargs -0 git add
+  printf "\n  %b✓%b changes re-staged\n" "$GREEN" "$RESET"
+else
+  printf "\n  %b✓%b all clean %b— no changes needed%b\n" "$GREEN" "$RESET" "$DIM" "$RESET"
+fi
+
+printf "\n"

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -37,14 +37,19 @@ else
   STATUS=$?
 fi
 
-# Strip pnpm script header noise, keep only biome output
-OUTPUT=$(printf "%s\n" "$OUTPUT" | grep -v "^>" | grep -v "^$" | sed 's/^ *//')
+# Strip pnpm + biome wrapper noise, keep only diagnostics and summary
+OUTPUT=$(printf "%s\n" "$OUTPUT" | grep -v "^>" | grep -v "ELIFECYCLE" | grep -v "^check " | grep -v "Some errors were emitted" | grep -v "^$" | sed 's/^ *//')
 
 if [ $STATUS -ne 0 ]; then
+  # Split output: biome summary line goes after diagnostics
+  DIAGNOSTICS=$(printf "%s\n" "$OUTPUT" | grep -v "^Checked \|^Found ")
+  SUMMARY=$(printf "%s\n" "$OUTPUT" | grep "^Checked \|^Found ")
+
   printf "\n"
-  printf "%s\n" "$OUTPUT" | while IFS= read -r line; do
+  printf "%s\n" "$DIAGNOSTICS" | while IFS= read -r line; do
     printf "    %s\n" "$line"
   done
+  printf "\n    %b%s%b\n" "$DIM" "$SUMMARY" "$RESET"
   printf "\n  %b✗ pre-commit failed%b %b— fix errors above and retry%b\n\n" "$RED" "$RESET" "$DIM" "$RESET"
   exit $STATUS
 fi

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,2 @@
 pnpx biome check --write --unsafe --no-errors-on-unmatched --staged
+

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -6,7 +6,6 @@ DIM='\033[2m'
 RESET='\033[0m'
 RED='\033[31m'
 GREEN='\033[32m'
-YELLOW='\033[33m'
 CYAN='\033[36m'
 
 # ─── Header ──────────────────────────────────────────────
@@ -28,20 +27,17 @@ printf "%s\n" "$STAGED" | while IFS= read -r f; do
   printf "    %b%s%b\n" "$DIM" "$f" "$RESET"
 done
 
-# ─── Run Biome ───────────────────────────────────────────
-printf "\n  %b▸%b running biome check\n" "$CYAN" "$RESET"
+# ─── Run lint-staged ─────────────────────────────────────
+printf "\n  %b▸%b running lint-staged %b(biome check + auto-fix)%b\n" "$CYAN" "$RESET" "$DIM" "$RESET"
 
-if OUTPUT=$(pnpm precommit 2>&1); then
-  STATUS=0
+if OUTPUT=$(pnpm lint-staged --quiet 2>&1); then
+  printf "\n  %b✓%b all clean\n" "$GREEN" "$RESET"
 else
   STATUS=$?
-fi
 
-# Strip pnpm + biome wrapper noise, keep only diagnostics and summary
-OUTPUT=$(printf "%s\n" "$OUTPUT" | grep -v "^>" | grep -v "ELIFECYCLE" | grep -v "^check " | grep -v "Some errors were emitted" | grep -v "^$" | sed 's/^ *//')
+  # Strip biome wrapper noise, keep diagnostics and summary
+  OUTPUT=$(printf "%s\n" "$OUTPUT" | grep -v "^check " | grep -v "Some errors were emitted" | grep -v "^$" | sed 's/^ *//')
 
-if [ $STATUS -ne 0 ]; then
-  # Split output: biome summary line goes after diagnostics
   DIAGNOSTICS=$(printf "%s\n" "$OUTPUT" | grep -v "^Checked \|^Found ")
   SUMMARY=$(printf "%s\n" "$OUTPUT" | grep "^Checked \|^Found ")
 
@@ -52,48 +48,6 @@ if [ $STATUS -ne 0 ]; then
   printf "\n    %b%s%b\n" "$DIM" "$SUMMARY" "$RESET"
   printf "\n  %b✗ pre-commit failed%b %b— fix errors above and retry%b\n\n" "$RED" "$RESET" "$DIM" "$RESET"
   exit $STATUS
-fi
-
-printf "    %b%s%b\n" "$DIM" "$OUTPUT" "$RESET"
-
-# ─── Detect auto-fixed files ────────────────────────────
-CHANGED=$(printf "%s\n" "$STAGED" | tr '\n' '\0' | xargs -0 git diff --name-only -- 2>/dev/null) || true
-
-if [ -n "$CHANGED" ]; then
-  CHANGED_COUNT=$(printf "%s\n" "$CHANGED" | wc -l | tr -d ' ')
-  printf "\n  %b✏%b  %b%s%b file(s) auto-fixed:\n\n" "$YELLOW" "$RESET" "$BOLD" "$CHANGED_COUNT" "$RESET"
-
-  # Compact stat summary
-  printf "%s\n" "$CHANGED" | tr '\n' '\0' | xargs -0 git diff --stat --color=always -- | while IFS= read -r line; do
-    printf "    %s\n" "$line"
-  done
-
-  # Diff detail
-  DIFF_LINES=$(printf "%s\n" "$CHANGED" | tr '\n' '\0' | xargs -0 git diff -- | wc -l | tr -d ' ')
-
-  if [ "$DIFF_LINES" -gt 0 ]; then
-    printf "\n  %b┌─ diff ─────────────────────────────%b\n" "$DIM" "$RESET"
-
-    if [ "$DIFF_LINES" -le 80 ]; then
-      printf "%s\n" "$CHANGED" | tr '\n' '\0' | xargs -0 git diff --color=always -- | while IFS= read -r line; do
-        printf "  %b│%b %s\n" "$DIM" "$RESET" "$line"
-      done
-    else
-      printf "%s\n" "$CHANGED" | tr '\n' '\0' | xargs -0 git diff --color=always -- | head -80 | while IFS= read -r line; do
-        printf "  %b│%b %s\n" "$DIM" "$RESET" "$line"
-      done
-      REMAINING=$((DIFF_LINES - 80))
-      printf "  %b│%b %b… %s more lines%b\n" "$DIM" "$RESET" "$DIM" "$REMAINING" "$RESET"
-    fi
-
-    printf "  %b└────────────────────────────────────%b\n" "$DIM" "$RESET"
-  fi
-
-  # Re-stage the fixed files
-  printf "%s\n" "$CHANGED" | tr '\n' '\0' | xargs -0 git add
-  printf "\n  %b✓%b changes re-staged\n" "$GREEN" "$RESET"
-else
-  printf "\n  %b✓%b all clean %b— no changes needed%b\n" "$GREEN" "$RESET" "$DIM" "$RESET"
 fi
 
 printf "\n"

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,1 @@
+pnpx biome check --write --unsafe --no-errors-on-unmatched --staged

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -27,10 +27,11 @@ printf "\n"
 
 FAILED=0
 
-# ─── Lint (full project) ────────────────────────────────
-printf "\n  %b▸%b running full project lint\n" "$CYAN" "$RESET"
+# ─── Lint (changed files since master) ───────────────────
+BASE_BRANCH="master"
+printf "\n  %b▸%b linting changes since %b%s%b\n" "$CYAN" "$RESET" "$DIM" "$BASE_BRANCH" "$RESET"
 
-if LINT_OUTPUT=$(pnpm lint 2>&1); then
+if LINT_OUTPUT=$(pnpm biome check --changed --since="$BASE_BRANCH" 2>&1); then
   LINT_SUMMARY=$(printf "%s\n" "$LINT_OUTPUT" | grep -v "^>" | grep -v "^$" | sed 's/^ *//')
   printf "    %b%s%b\n" "$DIM" "$LINT_SUMMARY" "$RESET"
   printf "  %b✓%b lint passed\n" "$GREEN" "$RESET"

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -50,6 +50,25 @@ else
   printf "\n  %b✗ lint failed%b\n" "$RED" "$RESET"
 fi
 
+# ─── Type check ──────────────────────────────────────────
+printf "\n  %b▸%b running type check\n" "$CYAN" "$RESET"
+
+if TSC_OUTPUT=$(pnpm tsc --noEmit 2>&1); then
+  printf "  %b✓%b types passed\n" "$GREEN" "$RESET"
+else
+  FAILED=1
+  printf "\n"
+  printf "%s\n" "$TSC_OUTPUT" \
+    | grep -v "^>" \
+    | grep -v "ELIFECYCLE" \
+    | grep -v "^$" \
+    | sed 's/^ *//' \
+    | while IFS= read -r line; do
+        printf "    %s\n" "$line"
+      done
+  printf "\n  %b✗ type check failed%b\n" "$RED" "$RESET"
+fi
+
 # ─── Tests ───────────────────────────────────────────────
 printf "\n  %b▸%b running tests\n" "$CYAN" "$RESET"
 

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -27,11 +27,10 @@ printf "\n"
 
 FAILED=0
 
-# ─── Lint (changed files since master) ───────────────────
-BASE_BRANCH="master"
-printf "\n  %b▸%b linting changes since %b%s%b\n" "$CYAN" "$RESET" "$DIM" "$BASE_BRANCH" "$RESET"
+# ─── Lint (full project) ─────────────────────────────────
+printf "\n  %b▸%b running full project lint\n" "$CYAN" "$RESET"
 
-if LINT_OUTPUT=$(pnpm biome check --changed --since="$BASE_BRANCH" 2>&1); then
+if LINT_OUTPUT=$(pnpm lint 2>&1); then
   LINT_SUMMARY=$(printf "%s\n" "$LINT_OUTPUT" | grep -v "^>" | grep -v "^$" | sed 's/^ *//')
   printf "    %b%s%b\n" "$DIM" "$LINT_SUMMARY" "$RESET"
   printf "  %b✓%b lint passed\n" "$GREEN" "$RESET"

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -6,6 +6,7 @@ DIM='\033[2m'
 RESET='\033[0m'
 RED='\033[31m'
 GREEN='\033[32m'
+YELLOW='\033[33m'
 CYAN='\033[36m'
 
 # ─── Header ──────────────────────────────────────────────
@@ -24,24 +25,47 @@ if [ "$COMMIT_COUNT" -gt 0 ] 2>/dev/null; then
 fi
 printf "\n"
 
-# ─── Build ───────────────────────────────────────────────
-printf "\n  %b▸%b running next build %b(type-check + compile)%b\n" "$CYAN" "$RESET" "$DIM" "$RESET"
+FAILED=0
 
-START_TIME=$(date +%s)
+# ─── Lint (full project) ────────────────────────────────
+printf "\n  %b▸%b running full project lint\n" "$CYAN" "$RESET"
 
-if OUTPUT=$(pnpm build 2>&1); then
-  STATUS=0
+if LINT_OUTPUT=$(pnpm lint 2>&1); then
+  LINT_SUMMARY=$(printf "%s\n" "$LINT_OUTPUT" | grep -v "^>" | grep -v "^$" | sed 's/^ *//')
+  printf "    %b%s%b\n" "$DIM" "$LINT_SUMMARY" "$RESET"
+  printf "  %b✓%b lint passed\n" "$GREEN" "$RESET"
 else
-  STATUS=$?
+  FAILED=1
+  printf "\n"
+  printf "%s\n" "$LINT_OUTPUT" \
+    | grep -v "^>" \
+    | grep -v "ELIFECYCLE" \
+    | grep -v "^check " \
+    | grep -v "Some errors were emitted" \
+    | grep -v "^$" \
+    | sed 's/^ *//' \
+    | while IFS= read -r line; do
+        printf "    %s\n" "$line"
+      done
+  printf "\n  %b✗ lint failed%b\n" "$RED" "$RESET"
 fi
 
-END_TIME=$(date +%s)
-DURATION=$((END_TIME - START_TIME))
+# ─── Tests ───────────────────────────────────────────────
+printf "\n  %b▸%b running tests\n" "$CYAN" "$RESET"
 
-if [ $STATUS -ne 0 ]; then
-  # Strip pnpm noise, show only meaningful error lines
+if TEST_OUTPUT=$(pnpm test 2>&1); then
+  TEST_SUMMARY=$(printf "%s\n" "$TEST_OUTPUT" | grep -v "^>" | grep -v "^$" | sed 's/^ *//')
+  if printf "%s" "$TEST_SUMMARY" | grep -qi "no tests"; then
+    printf "    %b%s%b\n" "$DIM" "$TEST_SUMMARY" "$RESET"
+    printf "  %b⊘%b no tests configured %b— skipping%b\n" "$YELLOW" "$RESET" "$DIM" "$RESET"
+  else
+    printf "    %b%s%b\n" "$DIM" "$TEST_SUMMARY" "$RESET"
+    printf "  %b✓%b tests passed\n" "$GREEN" "$RESET"
+  fi
+else
+  FAILED=1
   printf "\n"
-  printf "%s\n" "$OUTPUT" \
+  printf "%s\n" "$TEST_OUTPUT" \
     | grep -v "^>" \
     | grep -v "ELIFECYCLE" \
     | grep -v "^$" \
@@ -49,11 +73,14 @@ if [ $STATUS -ne 0 ]; then
     | while IFS= read -r line; do
         printf "    %s\n" "$line"
       done
-  printf "\n  %b✗ pre-push failed%b %b— build errors must be fixed before pushing (%ss)%b\n\n" "$RED" "$RESET" "$DIM" "$DURATION" "$RESET"
-  exit $STATUS
+  printf "\n  %b✗ tests failed%b\n" "$RED" "$RESET"
 fi
 
-printf "    %b✓ build succeeded in %ss%b\n" "$DIM" "$DURATION" "$RESET"
-printf "\n  %b✓%b good to push\n" "$GREEN" "$RESET"
-
+# ─── Result ──────────────────────────────────────────────
 printf "\n"
+if [ $FAILED -ne 0 ]; then
+  printf "  %b✗ pre-push failed%b %b— fix errors above before pushing%b\n\n" "$RED" "$RESET" "$DIM" "$RESET"
+  exit 1
+fi
+
+printf "  %b✓%b good to push\n\n" "$GREEN" "$RESET"

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,59 @@
+#!/bin/sh
+
+# ─── Colors & Formatting ────────────────────────────────
+BOLD='\033[1m'
+DIM='\033[2m'
+RESET='\033[0m'
+RED='\033[31m'
+GREEN='\033[32m'
+CYAN='\033[36m'
+
+# ─── Header ──────────────────────────────────────────────
+printf "\n"
+printf "  %b🔥 hibana%b %bpre-push%b\n" "$BOLD" "$RESET" "$DIM" "$RESET"
+printf "  %b━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━%b\n\n" "$DIM" "$RESET"
+
+# ─── Push info ───────────────────────────────────────────
+BRANCH=$(git branch --show-current)
+REMOTE="$1"
+COMMIT_COUNT=$(git log --oneline "${REMOTE}/${BRANCH}..HEAD" 2>/dev/null | wc -l | tr -d ' ')
+
+printf "  %b▸%b pushing %b%s%b → %b%s%b" "$CYAN" "$RESET" "$BOLD" "$BRANCH" "$RESET" "$DIM" "$REMOTE" "$RESET"
+if [ "$COMMIT_COUNT" -gt 0 ] 2>/dev/null; then
+  printf " %b(%s commit%s)%b" "$DIM" "$COMMIT_COUNT" "$([ "$COMMIT_COUNT" -ne 1 ] && echo 's')" "$RESET"
+fi
+printf "\n"
+
+# ─── Build ───────────────────────────────────────────────
+printf "\n  %b▸%b running next build %b(type-check + compile)%b\n" "$CYAN" "$RESET" "$DIM" "$RESET"
+
+START_TIME=$(date +%s)
+
+if OUTPUT=$(pnpm build 2>&1); then
+  STATUS=0
+else
+  STATUS=$?
+fi
+
+END_TIME=$(date +%s)
+DURATION=$((END_TIME - START_TIME))
+
+if [ $STATUS -ne 0 ]; then
+  # Strip pnpm noise, show only meaningful error lines
+  printf "\n"
+  printf "%s\n" "$OUTPUT" \
+    | grep -v "^>" \
+    | grep -v "ELIFECYCLE" \
+    | grep -v "^$" \
+    | tail -40 \
+    | while IFS= read -r line; do
+        printf "    %s\n" "$line"
+      done
+  printf "\n  %b✗ pre-push failed%b %b— build errors must be fixed before pushing (%ss)%b\n\n" "$RED" "$RESET" "$DIM" "$DURATION" "$RESET"
+  exit $STATUS
+fi
+
+printf "    %b✓ build succeeded in %ss%b\n" "$DIM" "$DURATION" "$RESET"
+printf "\n  %b✓%b good to push\n" "$GREEN" "$RESET"
+
+printf "\n"

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "babel-plugin-react-compiler": "1.0.0",
+    "husky": "^9.1.7",
     "supabase": "^2.72.3",
     "tailwindcss": "^4",
     "typescript": "^5"

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "db:stop": "pnpx supabase stop",
     "db:reset": "pnpx supabase db reset",
     "db:push": "pnpx supabase db push",
-    "db:gentypes": "pnpx supabase gen types typescript --local > utils/supabase/types.ts"
+    "db:gentypes": "pnpx supabase gen types typescript --local > utils/supabase/types.ts",
+    "prepare": "husky"
   },
   "dependencies": {
     "@base-ui/react": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
     "db:push": "pnpx supabase db push",
     "db:gentypes": "pnpx supabase gen types typescript --local > utils/supabase/types.ts",
     "prepare": "husky",
-    "precommit": "biome check --write --unsafe --no-errors-on-unmatched --staged",
     "test": "echo \"No tests configured yet\""
   },
   "dependencies": {
@@ -52,9 +51,15 @@
     "@types/react-dom": "^19",
     "babel-plugin-react-compiler": "1.0.0",
     "husky": "^9.1.7",
+    "lint-staged": "^16.4.0",
     "supabase": "^2.72.3",
     "tailwindcss": "^4",
     "typescript": "^5"
+  },
+  "lint-staged": {
+    "*.{ts,tsx,js,jsx,json}": [
+      "biome check --write --unsafe"
+    ]
   },
   "packageManager": "pnpm@10.33.0+sha512.10568bb4a6afb58c9eb3630da90cc9516417abebd3fabbe6739f0ae795728da1491e9db5a544c76ad8eb7570f5c4bb3d6c637b2cb41bfdcdb47fa823c8649319"
 }

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "db:push": "pnpx supabase db push",
     "db:gentypes": "pnpx supabase gen types typescript --local > utils/supabase/types.ts",
     "prepare": "husky",
-    "precommit": "biome check --write --unsafe --no-errors-on-unmatched --staged"
+    "precommit": "biome check --write --unsafe --no-errors-on-unmatched --staged",
+    "test": "echo \"No tests configured yet\""
   },
   "dependencies": {
     "@base-ui/react": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "db:reset": "pnpx supabase db reset",
     "db:push": "pnpx supabase db push",
     "db:gentypes": "pnpx supabase gen types typescript --local > utils/supabase/types.ts",
-    "prepare": "husky"
+    "prepare": "husky",
+    "precommit": "biome check --write --unsafe --no-errors-on-unmatched --staged"
   },
   "dependencies": {
     "@base-ui/react": "^1.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -102,6 +102,9 @@ importers:
       babel-plugin-react-compiler:
         specifier: 1.0.0
         version: 1.0.0
+      husky:
+        specifier: ^9.1.7
+        version: 9.1.7
       supabase:
         specifier: ^2.72.3
         version: 2.72.3
@@ -314,24 +317,28 @@ packages:
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@biomejs/cli-linux-arm64@2.3.10':
     resolution: {integrity: sha512-hhPw2V3/EpHKsileVOFynuWiKRgFEV48cLe0eA+G2wO4SzlwEhLEB9LhlSrVeu2mtSn205W283LkX7Fh48CaxA==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@biomejs/cli-linux-x64-musl@2.3.10':
     resolution: {integrity: sha512-QTfHZQh62SDFdYc2nfmZFuTm5yYb4eO1zwfB+90YxUumRCR171tS1GoTX5OD0wrv4UsziMPmrePMtkTnNyYG3g==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@biomejs/cli-linux-x64@2.3.10':
     resolution: {integrity: sha512-wwAkWD1MR95u+J4LkWP74/vGz+tRrIQvr8kfMMJY8KOQ8+HMVleREOcPYsQX82S7uueco60L58Wc6M1I9WA9Dw==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@biomejs/cli-win32-arm64@2.3.10':
     resolution: {integrity: sha512-o7lYc9n+CfRbHvkjPhm8s9FgbKdYZu5HCcGVMItLjz93EhgJ8AM44W+QckDqLA9MKDNFrR8nPbO4b73VC5kGGQ==}
@@ -448,89 +455,105 @@ packages:
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
     resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.5':
     resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.5':
     resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.34.5':
     resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.5':
     resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-wasm32@0.34.5':
     resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
@@ -652,24 +675,28 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@next/swc-linux-arm64-musl@16.1.1':
     resolution: {integrity: sha512-MFHrgL4TXNQbBPzkKKur4Fb5ICEJa87HM7fczFs2+HWblM7mMLdco3dvyTI+QmLBU9xgns/EeeINSZD6Ar+oLg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@next/swc-linux-x64-gnu@16.1.1':
     resolution: {integrity: sha512-20bYDfgOQAPUkkKBnyP9PTuHiJGM7HzNBbuqmD0jiFVZ0aOldz+VnJhbxzjcSabYsnNjMPsE0cyzEudpYxsrUQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@next/swc-linux-x64-musl@16.1.1':
     resolution: {integrity: sha512-9pRbK3M4asAHQRkwaXwu601oPZHghuSC8IXNENgbBSyImHv/zY4K5udBusgdHkvJ/Tcr96jJwQYOll0qU8+fPA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@next/swc-win32-arm64-msvc@16.1.1':
     resolution: {integrity: sha512-bdfQkggaLgnmYrFkSQfsHfOhk/mCYmjnrbRCGgkMcoOBZ4n+TRRSLmT/CU5SATzlBJ9TpioUyBW/vWFXTqQRiA==}
@@ -749,36 +776,42 @@ packages:
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@parcel/watcher-linux-arm-musl@2.5.1':
     resolution: {integrity: sha512-6E+m/Mm1t1yhB8X412stiKFG3XykmgdIOqhjWj+VL8oHkKABfu/gjFj8DvLrYVHSBNC+/u5PeNrujiSQ1zwd1Q==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@parcel/watcher-linux-arm64-glibc@2.5.1':
     resolution: {integrity: sha512-LrGp+f02yU3BN9A+DGuY3v3bmnFUggAITBGriZHUREfNEzZh/GO06FF5u2kx8x+GBEUYfyTGamol4j3m9ANe8w==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@parcel/watcher-linux-arm64-musl@2.5.1':
     resolution: {integrity: sha512-cFOjABi92pMYRXS7AcQv9/M1YuKRw8SZniCDw0ssQb/noPkRzA+HBDkwmyOJYp5wXcsTrhxO0zq1U11cK9jsFg==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@parcel/watcher-linux-x64-glibc@2.5.1':
     resolution: {integrity: sha512-GcESn8NZySmfwlTsIur+49yDqSny2IhPeZfXunQi48DMugKeZ7uy1FX83pO0X22sHntJ4Ub+9k34XQCX+oHt2A==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@parcel/watcher-linux-x64-musl@2.5.1':
     resolution: {integrity: sha512-n0E2EQbatQ3bXhcH2D1XIAANAcTZkQICBPVaxMeaCVBtOpBZpWJuf7LwyWPSBDITb7In8mqQgJ7gH8CILCURXg==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@parcel/watcher-win32-arm64@2.5.1':
     resolution: {integrity: sha512-RFzklRvmc3PkjKjry3hLF9wD7ppR4AKcWNzH7kXR7GUe0Igb3Nz8fyPwtZCSquGrhU5HhUNDr/mKBqj7tqA2Vw==}
@@ -1560,24 +1593,28 @@ packages:
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@swc/core-linux-arm64-musl@1.15.8':
     resolution: {integrity: sha512-koiCqL09EwOP1S2RShCI7NbsQuG6r2brTqUYE7pV7kZm9O17wZ0LSz22m6gVibpwEnw8jI3IE1yYsQTVpluALw==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@swc/core-linux-x64-gnu@1.15.8':
     resolution: {integrity: sha512-4p6lOMU3bC+Vd5ARtKJ/FxpIC5G8v3XLoPEZ5s7mLR8h7411HWC/LmTXDHcrSXRC55zvAVia1eldy6zDLz8iFQ==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@swc/core-linux-x64-musl@1.15.8':
     resolution: {integrity: sha512-z3XBnbrZAL+6xDGAhJoN4lOueIxC/8rGrJ9tg+fEaeqLEuAtHSW2QHDHxDwkxZMjuF/pZ6MUTjHjbp8wLbuRLA==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@swc/core-win32-arm64-msvc@1.15.8':
     resolution: {integrity: sha512-djQPJ9Rh9vP8GTS/Df3hcc6XP6xnG5c8qsngWId/BLA9oX6C7UzCPAn74BG/wGb9a6j4w3RINuoaieJB3t+7iQ==}
@@ -1653,24 +1690,28 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.1.18':
     resolution: {integrity: sha512-1px92582HkPQlaaCkdRcio71p8bc8i/ap5807tPRDK/uw953cauQBT8c5tVGkOwrHMfc2Yh6UuxaH4vtTjGvHg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.1.18':
     resolution: {integrity: sha512-v3gyT0ivkfBLoZGF9LyHmts0Isc8jHZyVcbzio6Wpzifg/+5ZJpDiRiUhDLkcr7f/r38SWNe7ucxmGW3j3Kb/g==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.1.18':
     resolution: {integrity: sha512-bhJ2y2OQNlcRwwgOAGMY0xTFStt4/wyU6pvI6LSuZpRgKQwxTec0/3Scu91O8ir7qCR3AuepQKLU/kX99FouqQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.1.18':
     resolution: {integrity: sha512-LffYTvPjODiP6PT16oNeUQJzNVyJl1cjIebq/rWWBF+3eDst5JGEFSc5cWxyRCJ0Mxl+KyIkqRxk1XPEs9x8TA==}
@@ -2294,6 +2335,11 @@ packages:
     resolution: {integrity: sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ==}
     engines: {node: '>=18.18.0'}
 
+  husky@9.1.7:
+    resolution: {integrity: sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   iceberg-js@0.8.1:
     resolution: {integrity: sha512-1dhVQZXhcHje7798IVM+xoo/1ZdVfzOMIc8/rgVSijRK38EDqOJoGula9N/8ZI5RD8QTxNQtK/Gozpr+qUqRRA==}
     engines: {node: '>=20.0.0'}
@@ -2494,24 +2540,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.30.2:
     resolution: {integrity: sha512-5Vh9dGeblpTxWHpOx8iauV02popZDsCYMPIgiuw97OJ5uaDsL86cnqSFs5LZkG3ghHoX5isLgWzMs+eD1YzrnA==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.30.2:
     resolution: {integrity: sha512-Cfd46gdmj1vQ+lR6VRTTadNHu6ALuw2pKR9lYq4FnhvgBc4zWY1EtZcAc6EffShbb1MFrIPfLDXD6Xprbnni4w==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.30.2:
     resolution: {integrity: sha512-XJaLUUFXb6/QG2lGIW6aIk6jKdtjtcffUT0NKvIqhSBY3hh9Ch+1LCeH80dR9q9LBjG3ewbDjnumefsLsP6aiA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.30.2:
     resolution: {integrity: sha512-FZn+vaj7zLv//D/192WFFVA0RgHawIcHqLX9xuWiQt7P0PtdFEVaxgF9rjM/IRYHQXNnk61/H/gb2Ei+kUQ4xQ==}
@@ -5420,6 +5470,8 @@ snapshots:
   human-signals@2.1.0: {}
 
   human-signals@8.0.1: {}
+
+  husky@9.1.7: {}
 
   iceberg-js@0.8.1: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -105,6 +105,9 @@ importers:
       husky:
         specifier: ^9.1.7
         version: 9.1.7
+      lint-staged:
+        specifier: ^16.4.0
+        version: 16.4.0
       supabase:
         specifier: ^2.72.3
         version: 2.72.3
@@ -1845,6 +1848,10 @@ packages:
   ajv@8.17.1:
     resolution: {integrity: sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==}
 
+  ansi-escapes@7.3.0:
+    resolution: {integrity: sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==}
+    engines: {node: '>=18'}
+
   ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
     engines: {node: '>=8'}
@@ -1856,6 +1863,10 @@ packages:
   ansi-styles@4.3.0:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
+
+  ansi-styles@6.2.3:
+    resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
+    engines: {node: '>=12'}
 
   ansis@4.2.0:
     resolution: {integrity: sha512-HqZ5rWlFjGiV0tDm3UxxgNRqsOTniqoKZu0pIAfh7TZQMGuZK+hH0drySty0si0QXj1ieop4+SkSfPZBPPkHig==}
@@ -1938,6 +1949,10 @@ packages:
     resolution: {integrity: sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==}
     engines: {node: '>=6'}
 
+  cli-truncate@5.2.0:
+    resolution: {integrity: sha512-xRwvIOMGrfOAnM1JYtqQImuaNtDEv9v6oIYAs4LIHwTiKee8uwvIi363igssOC0O5U04i4AlENs79LQLu9tEMw==}
+    engines: {node: '>=20'}
+
   cli-width@4.1.0:
     resolution: {integrity: sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==}
     engines: {node: '>= 12'}
@@ -1967,12 +1982,19 @@ packages:
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
 
+  colorette@2.0.20:
+    resolution: {integrity: sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==}
+
   commander@11.1.0:
     resolution: {integrity: sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==}
     engines: {node: '>=16'}
 
   commander@14.0.2:
     resolution: {integrity: sha512-TywoWNNRbhoD0BXs1P3ZEScW8W5iKrnbithIl0YH+uCmBd0QpPOA8yc82DS3BIE5Ma6FnBVUsJ7wVUDz4dvOWQ==}
+    engines: {node: '>=20'}
+
+  commander@14.0.3:
+    resolution: {integrity: sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==}
     engines: {node: '>=20'}
 
   content-disposition@1.0.1:
@@ -2119,6 +2141,10 @@ packages:
     resolution: {integrity: sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==}
     engines: {node: '>=6'}
 
+  environment@1.1.0:
+    resolution: {integrity: sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==}
+    engines: {node: '>=18'}
+
   error-ex@1.3.4:
     resolution: {integrity: sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==}
 
@@ -2149,6 +2175,9 @@ packages:
   etag@1.8.1:
     resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
     engines: {node: '>= 0.6'}
+
+  eventemitter3@5.0.4:
+    resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
 
   eventsource-parser@3.0.6:
     resolution: {integrity: sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==}
@@ -2263,6 +2292,10 @@ packages:
 
   get-east-asian-width@1.4.0:
     resolution: {integrity: sha512-QZjmEOC+IT1uk6Rx0sX22V6uHWVwbdbxf1faPqJ1QhLdGgsRGCZoyaQBm/piRdJy/D2um6hM1UP7ZEeQ4EkP+Q==}
+    engines: {node: '>=18'}
+
+  get-east-asian-width@1.5.0:
+    resolution: {integrity: sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA==}
     engines: {node: '>=18'}
 
   get-intrinsic@1.3.0:
@@ -2391,6 +2424,10 @@ packages:
   is-fullwidth-code-point@3.0.0:
     resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
     engines: {node: '>=8'}
+
+  is-fullwidth-code-point@5.1.0:
+    resolution: {integrity: sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==}
+    engines: {node: '>=18'}
 
   is-glob@4.0.3:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
@@ -2582,8 +2619,21 @@ packages:
   lines-and-columns@1.2.4:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
 
+  lint-staged@16.4.0:
+    resolution: {integrity: sha512-lBWt8hujh/Cjysw5GYVmZpFHXDCgZzhrOm8vbcUdobADZNOK/bRshr2kM3DfgrrtR1DQhfupW9gnIXOfiFi+bw==}
+    engines: {node: '>=20.17'}
+    hasBin: true
+
+  listr2@9.0.5:
+    resolution: {integrity: sha512-ME4Fb83LgEgwNw96RKNvKV4VTLuXfoKudAmm2lP8Kk87KaMK0/Xrx/aAkMWmT8mDb+3MlFDspfbCs7adjRxA2g==}
+    engines: {node: '>=20.0.0'}
+
   log-symbols@6.0.0:
     resolution: {integrity: sha512-i24m8rpwhmPIS4zscNzK6MSEhk0DUWa/8iYQWxhffV8jkI4Phvs3F+quL5xvS0gdQR0FyTCMMH33Y78dDTzzIw==}
+    engines: {node: '>=18'}
+
+  log-update@6.1.0:
+    resolution: {integrity: sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w==}
     engines: {node: '>=18'}
 
   lru-cache@5.1.1:
@@ -2981,6 +3031,9 @@ packages:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
 
+  rfdc@1.4.1:
+    resolution: {integrity: sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==}
+
   router@2.2.0:
     resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
     engines: {node: '>= 18'}
@@ -3060,6 +3113,14 @@ packages:
   sisteransi@1.0.5:
     resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
 
+  slice-ansi@7.1.2:
+    resolution: {integrity: sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w==}
+    engines: {node: '>=18'}
+
+  slice-ansi@8.0.0:
+    resolution: {integrity: sha512-stxByr12oeeOyY2BlviTNQlYV5xOj47GirPr4yA1hE9JCtxfQN0+tVbkxwCtYDQWhEKWFHsEK48ORg5jrouCAg==}
+    engines: {node: '>=20'}
+
   sonner@2.0.7:
     resolution: {integrity: sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w==}
     peerDependencies:
@@ -3085,6 +3146,10 @@ packages:
   strict-event-emitter@0.5.1:
     resolution: {integrity: sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==}
 
+  string-argv@0.3.2:
+    resolution: {integrity: sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==}
+    engines: {node: '>=0.6.19'}
+
   string-width@4.2.3:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
     engines: {node: '>=8'}
@@ -3092,6 +3157,10 @@ packages:
   string-width@7.2.0:
     resolution: {integrity: sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==}
     engines: {node: '>=18'}
+
+  string-width@8.2.1:
+    resolution: {integrity: sha512-IIaP0g3iy9Cyy18w3M9YcaDudujEAVHKt3a3QJg1+sr/oX96TbaGUubG0hJyCjCBThFH+tFpcIyoUHUn1ogaLA==}
+    engines: {node: '>=20'}
 
   stringify-object@5.0.0:
     resolution: {integrity: sha512-zaJYxz2FtcMb4f+g60KsRNFOpVMUyuJgA51Zi5Z1DOTC3S59+OQiVOzE9GZt0x72uBGWKsQIuBKeF9iusmKFsg==}
@@ -3161,6 +3230,10 @@ packages:
 
   tinyexec@1.0.2:
     resolution: {integrity: sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==}
+    engines: {node: '>=18'}
+
+  tinyexec@1.1.1:
+    resolution: {integrity: sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==}
     engines: {node: '>=18'}
 
   tldts-core@7.0.19:
@@ -3291,6 +3364,10 @@ packages:
     resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
     engines: {node: '>=10'}
 
+  wrap-ansi@9.0.2:
+    resolution: {integrity: sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==}
+    engines: {node: '>=18'}
+
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
@@ -3324,6 +3401,11 @@ packages:
   yallist@5.0.0:
     resolution: {integrity: sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==}
     engines: {node: '>=18'}
+
+  yaml@2.8.3:
+    resolution: {integrity: sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==}
+    engines: {node: '>= 14.6'}
+    hasBin: true
 
   yargs-parser@21.1.1:
     resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
@@ -5015,6 +5097,10 @@ snapshots:
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
+  ansi-escapes@7.3.0:
+    dependencies:
+      environment: 1.1.0
+
   ansi-regex@5.0.1: {}
 
   ansi-regex@6.2.2: {}
@@ -5022,6 +5108,8 @@ snapshots:
   ansi-styles@4.3.0:
     dependencies:
       color-convert: 2.0.1
+
+  ansi-styles@6.2.3: {}
 
   ansis@4.2.0: {}
 
@@ -5109,6 +5197,11 @@ snapshots:
 
   cli-spinners@2.9.2: {}
 
+  cli-truncate@5.2.0:
+    dependencies:
+      slice-ansi: 8.0.0
+      string-width: 8.2.1
+
   cli-width@4.1.0: {}
 
   client-only@0.0.1: {}
@@ -5131,9 +5224,13 @@ snapshots:
 
   color-name@1.1.4: {}
 
+  colorette@2.0.20: {}
+
   commander@11.1.0: {}
 
   commander@14.0.2: {}
+
+  commander@14.0.3: {}
 
   content-disposition@1.0.1: {}
 
@@ -5234,6 +5331,8 @@ snapshots:
 
   env-paths@2.2.1: {}
 
+  environment@1.1.0: {}
+
   error-ex@1.3.4:
     dependencies:
       is-arrayish: 0.2.1
@@ -5253,6 +5352,8 @@ snapshots:
   esprima@4.0.1: {}
 
   etag@1.8.1: {}
+
+  eventemitter3@5.0.4: {}
 
   eventsource-parser@3.0.6: {}
 
@@ -5403,6 +5504,8 @@ snapshots:
 
   get-east-asian-width@1.4.0: {}
 
+  get-east-asian-width@1.5.0: {}
+
   get-intrinsic@1.3.0:
     dependencies:
       call-bind-apply-helpers: 1.0.2
@@ -5511,6 +5614,10 @@ snapshots:
   is-extglob@2.1.1: {}
 
   is-fullwidth-code-point@3.0.0: {}
+
+  is-fullwidth-code-point@5.1.0:
+    dependencies:
+      get-east-asian-width: 1.4.0
 
   is-glob@4.0.3:
     dependencies:
@@ -5635,10 +5742,36 @@ snapshots:
 
   lines-and-columns@1.2.4: {}
 
+  lint-staged@16.4.0:
+    dependencies:
+      commander: 14.0.3
+      listr2: 9.0.5
+      picomatch: 4.0.3
+      string-argv: 0.3.2
+      tinyexec: 1.1.1
+      yaml: 2.8.3
+
+  listr2@9.0.5:
+    dependencies:
+      cli-truncate: 5.2.0
+      colorette: 2.0.20
+      eventemitter3: 5.0.4
+      log-update: 6.1.0
+      rfdc: 1.4.1
+      wrap-ansi: 9.0.2
+
   log-symbols@6.0.0:
     dependencies:
       chalk: 5.6.2
       is-unicode-supported: 1.3.0
+
+  log-update@6.1.0:
+    dependencies:
+      ansi-escapes: 7.3.0
+      cli-cursor: 5.0.0
+      slice-ansi: 7.1.2
+      strip-ansi: 7.1.2
+      wrap-ansi: 9.0.2
 
   lru-cache@5.1.1:
     dependencies:
@@ -6060,6 +6193,8 @@ snapshots:
 
   reusify@1.1.0: {}
 
+  rfdc@1.4.1: {}
+
   router@2.2.0:
     dependencies:
       debug: 4.4.3
@@ -6226,6 +6361,16 @@ snapshots:
 
   sisteransi@1.0.5: {}
 
+  slice-ansi@7.1.2:
+    dependencies:
+      ansi-styles: 6.2.3
+      is-fullwidth-code-point: 5.1.0
+
+  slice-ansi@8.0.0:
+    dependencies:
+      ansi-styles: 6.2.3
+      is-fullwidth-code-point: 5.1.0
+
   sonner@2.0.7(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
     dependencies:
       react: 19.2.3
@@ -6241,6 +6386,8 @@ snapshots:
 
   strict-event-emitter@0.5.1: {}
 
+  string-argv@0.3.2: {}
+
   string-width@4.2.3:
     dependencies:
       emoji-regex: 8.0.0
@@ -6251,6 +6398,11 @@ snapshots:
     dependencies:
       emoji-regex: 10.6.0
       get-east-asian-width: 1.4.0
+      strip-ansi: 7.1.2
+
+  string-width@8.2.1:
+    dependencies:
+      get-east-asian-width: 1.5.0
       strip-ansi: 7.1.2
 
   stringify-object@5.0.0:
@@ -6310,6 +6462,8 @@ snapshots:
   tiny-invariant@1.3.3: {}
 
   tinyexec@1.0.2: {}
+
+  tinyexec@1.1.1: {}
 
   tldts-core@7.0.19: {}
 
@@ -6422,6 +6576,12 @@ snapshots:
       string-width: 4.2.3
       strip-ansi: 6.0.1
 
+  wrap-ansi@9.0.2:
+    dependencies:
+      ansi-styles: 6.2.3
+      string-width: 7.2.0
+      strip-ansi: 7.1.2
+
   wrappy@1.0.2: {}
 
   write-file-atomic@7.0.0:
@@ -6441,6 +6601,8 @@ snapshots:
   yallist@3.1.1: {}
 
   yallist@5.0.0: {}
+
+  yaml@2.8.3: {}
 
   yargs-parser@21.1.1: {}
 


### PR DESCRIPTION
Adds git hooks to run biome linter and formatter to ensure code quality. Pre-commit runs on staged changes whereas pre-push runs a lint on the whole codebase with tsc as a sanity check.

pre-commit:
- linting
- formatting
- staged changes only

pre-push:
- lint
- tsc
- whole codebase

If pushing is blocked due to unrelated changes to the current branch (this should never happen if the codebase is maintained properly), it can be skipped via the `--no-verify` flag.