### PR TITLE
chore(tooling): VScode workspace config

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,9 @@
 {
-    "i18n-ally.localesPaths": [
-        "i18n",
-        "messages"
-    ]
+  "i18n-ally.localesPaths": ["i18n", "messages"],
+  "editor.formatOnSave": true,
+  "editor.codeActionsOnSave": {
+    "source.fixAll.biome": "explicit",
+    "source.organizeImports.biome": "explicit"
+  },
+  "editor.defaultFormatter": "biomejs.biome"
 }


### PR DESCRIPTION
Add vscode config to automatically use Biome linter and formatter