### PR TITLE
chore(tooling): Use Biome for CSS linting by disabling VScode validator

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,5 +5,6 @@
     "source.fixAll.biome": "explicit",
     "source.organizeImports.biome": "explicit"
   },
-  "editor.defaultFormatter": "biomejs.biome"
+  "editor.defaultFormatter": "biomejs.biome",
+  "css.validate": false
 }


### PR DESCRIPTION
Fixes some false warnings caused by the VSCode CSS validator which does not have tailwind directive support. Project is configured to use Biome's linter instead which has Tailwind support built in