### PR TITLE
ref: Use modern Supabase publishable key naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,5 +29,14 @@ Create a `.env.local` file with your Supabase credentials:
 
 ```env
 NEXT_PUBLIC_SUPABASE_URL=your_supabase_url
-NEXT_PUBLIC_SUPABASE_ANON_KEY=your_supabase_anon_key
+NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY=your_supabase_publishable_key
+SUPABASE_SECRET_KEY=your_supabase_secret_key
 ```
+
+The publishable key (`sb_publishable_...`) is safe to expose in the browser and
+is used by the client and SSR Supabase clients. The secret key (`sb_secret_...`)
+must never be exposed publicly — it is only read server-side for privileged
+operations that bypass RLS.
+
+For local development, run `pnpx supabase start` and copy the `Publishable key`
+and `Secret key` it prints into your `.env.local`.

--- a/lib/supabase/env.ts
+++ b/lib/supabase/env.ts
@@ -1,7 +1,6 @@
 export function getSupabaseCredentials() {
   const publicUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
-  const publishableKey =
-    process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_DEFAULT_KEY;
+  const publishableKey = process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY;
 
   if (!publicUrl) {
     throw new Error(


### PR DESCRIPTION
## Summary

Supabase has migrated away from the legacy `anon` / `service_role` API keys to a new pair: **publishable** keys (safe in the browser) and **secret** keys (server-only, privileged). This PR audits the codebase and aligns naming with the new convention.

### Changes

- **`lib/supabase/env.ts`** — Rename the env var read for the browser-safe key from `NEXT_PUBLIC_SUPABASE_PUBLISHABLE_DEFAULT_KEY` to the standard `NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY`. The `_DEFAULT_` infix was non-standard and inconsistent with Supabase's documented convention.
- **`README.md`** — Replace the legacy `NEXT_PUBLIC_SUPABASE_ANON_KEY` instruction with `NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY`, document `SUPABASE_SECRET_KEY` for privileged server use, and add a short note distinguishing the two keys plus how to grab them from `pnpx supabase start` for local dev.

### Audit notes

- `lib/supabase/server.ts` already reads `SUPABASE_SECRET_KEY` for the service-role-style client — no change needed.
- `lib/supabase/client.ts` and `lib/supabase/proxy.ts` route through `getSupabaseCredentials()`, so they pick up the rename automatically.
- SQL `anon` / `service_role` references in `supabase/migrations/*.sql` are Postgres role grants, not API keys — left untouched.
- `supabase/config.toml` has no legacy key references requiring changes.

### Action required after merge

Anyone with a `.env.local` will need to rename `NEXT_PUBLIC_SUPABASE_PUBLISHABLE_DEFAULT_KEY` → `NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY` (and add `SUPABASE_SECRET_KEY` if missing). Vercel/CI env vars should be updated accordingly.

## Test plan

- [ ] `pnpm lint` passes
- [ ] `pnpm dev` boots locally with renamed env var and auth still works
- [ ] Server actions that use `createServiceClient()` still succeed (secret key path unchanged)

---
_Generated by [Claude Code](https://claude.ai/code/session_01E2nDmvHS1TwAVaupM5LVEK)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated Supabase environment variable setup documentation with expanded examples.
  * Added guidance for obtaining Supabase credentials locally via command-line tools.
  * Documented environment variable usage distinctions for client and server-side operations.

* **Configuration Updates**
  * Revised environment variable naming conventions for Supabase authentication setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->