### PR TITLE
ref(db): Refactor user tables and tighten RLS policies

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,6 +18,7 @@ See @package.json for available scripts for this project.
 
 - **RLS Policy Principle of Least Privilege**: Before adding an INSERT, UPDATE, or DELETE RLS policy, consider whether the operation is performed by the client (via `createClientWithAuth`) or by the server (via SECURITY DEFINER RPCs / `createServiceClient`). If a table is only mutated by server-side RPCs, clients should only have a SELECT policy. SECURITY DEFINER functions bypass RLS, so they don't need client-facing write policies.
 - **Trigger-managed rows**: Tables like `profiles` and `user_state` that are auto-created by database triggers (SECURITY DEFINER) don't need client INSERT policies.
+- **Applying migrations locally**: Use `pnpm db:migrate` to apply pending migrations to the local database. Never use `db:reset` to test migrations as it wipes all local data. `db:push` is for pushing to the remote/production database only.
 
 ## Workflow
 - Create a new appropriately named branch before making changes

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,6 +14,11 @@ Gamified productivity platform using fire/flame metaphors. Habits are Flames, Ti
 ## Scripts
 See @package.json for available scripts for this project.
 
+## Database Migrations
+
+- **RLS Policy Principle of Least Privilege**: Before adding an INSERT, UPDATE, or DELETE RLS policy, consider whether the operation is performed by the client (via `createClientWithAuth`) or by the server (via SECURITY DEFINER RPCs / `createServiceClient`). If a table is only mutated by server-side RPCs, clients should only have a SELECT policy. SECURITY DEFINER functions bypass RLS, so they don't need client-facing write policies.
+- **Trigger-managed rows**: Tables like `profiles` and `user_state` that are auto-created by database triggers (SECURITY DEFINER) don't need client INSERT policies.
+
 ## Workflow
 - Create a new appropriately named branch before making changes
 - Run linter and formatter before committing

--- a/app/(app)/components/ProfileBadge.tsx
+++ b/app/(app)/components/ProfileBadge.tsx
@@ -19,7 +19,7 @@ import Link from 'next/link';
 import { useTranslations } from 'next-intl';
 import { useEffect, useRef, useState } from 'react';
 import { getFlameLevel } from '@/app/(app)/flames/utils/levels';
-import { getOrCreateUserState } from '@/app/(app)/shop/actions';
+import { getUserState } from '@/app/(app)/shop/actions';
 import {
   Popover,
   PopoverContent,
@@ -195,7 +195,7 @@ export function ProfileBadge({
     let cancelled = false;
     async function fetchUserState() {
       try {
-        const result = await getOrCreateUserState();
+        const result = await getUserState();
         if (cancelled) return;
         setSparks(result.success ? result.data.sparks_balance : 0);
       } catch {

--- a/app/(app)/shop/actions.ts
+++ b/app/(app)/shop/actions.ts
@@ -4,7 +4,7 @@ import { calculateSparks } from '@/lib/sparks';
 import type {
   Item,
   SparkTransaction,
-  UserInventory,
+  UserItem,
   UserState,
 } from '@/lib/supabase/rows';
 import {
@@ -15,51 +15,34 @@ import type { ActionResult } from '@/lib/types';
 import { parseLocalDate } from '@/lib/utils';
 
 /**
- * Returns the user's state row, lazy-creating one if it doesn't exist yet.
+ * Returns the user's state row (auto-created on signup by handle_new_user trigger).
  */
-export async function getOrCreateUserState(): ActionResult<UserState> {
+export async function getUserState(): ActionResult<UserState> {
   const { supabase, user } = await createClientWithAuth();
 
   const { data, error } = await supabase
     .from('user_state')
     .select()
     .eq('user_id', user.id)
-    .maybeSingle();
+    .single();
 
   if (error) {
     return { success: false, error };
   }
 
-  if (data) {
-    return { success: true, data };
-  }
-
-  // Lazy-insert a fresh row
-  const { data: created, error: insertError } = await supabase
-    .from('user_state')
-    .insert({ user_id: user.id })
-    .select()
-    .single();
-
-  if (insertError) {
-    return { success: false, error: insertError };
-  }
-
-  return { success: true, data: created };
+  return { success: true, data };
 }
 
-type InventoryItemWithDetails = UserInventory & { items: Item };
+type UserItemWithDetails = UserItem & { items: Item };
 
 /**
- * Returns the user's inventory with joined item details.
+ * Returns the user's items with joined item details.
  */
-export async function getUserInventory(): ActionResult<
-  InventoryItemWithDetails[]
-> {
+export async function getUserItems(): ActionResult<UserItemWithDetails[]> {
   const { supabase, user } = await createClientWithAuth();
 
   const { data, error } = await supabase
-    .from('user_inventory')
+    .from('user_items')
     .select('*, items(*)')
     .eq('user_id', user.id)
     .order('acquired_at', { ascending: false });
@@ -68,7 +51,7 @@ export async function getUserInventory(): ActionResult<
     return { success: false, error };
   }
 
-  return { success: true, data: data as InventoryItemWithDetails[] };
+  return { success: true, data: data as UserItemWithDetails[] };
 }
 
 /**

--- a/lib/supabase/rows.ts
+++ b/lib/supabase/rows.ts
@@ -9,7 +9,6 @@ export type FlameSession =
   Database['public']['Tables']['flame_sessions']['Row'];
 export type UserState = Database['public']['Tables']['user_state']['Row'];
 export type Item = Database['public']['Tables']['items']['Row'];
-export type UserInventory =
-  Database['public']['Tables']['user_inventory']['Row'];
+export type UserItem = Database['public']['Tables']['user_items']['Row'];
 export type SparkTransaction =
   Database['public']['Tables']['spark_transactions']['Row'];

--- a/lib/supabase/types.ts
+++ b/lib/supabase/types.ts
@@ -202,6 +202,7 @@ export type Database = {
           description: string | null;
           id: string;
           is_active: boolean;
+          is_equippable: boolean;
           metadata: Json;
           name: string;
           type: string;
@@ -212,6 +213,7 @@ export type Database = {
           description?: string | null;
           id?: string;
           is_active?: boolean;
+          is_equippable?: boolean;
           metadata?: Json;
           name: string;
           type: string;
@@ -222,6 +224,7 @@ export type Database = {
           description?: string | null;
           id?: string;
           is_active?: boolean;
+          is_equippable?: boolean;
           metadata?: Json;
           name?: string;
           type?: string;
@@ -257,24 +260,21 @@ export type Database = {
           avatar_url: string | null;
           bio: string | null;
           created_at: string;
-          id: number;
-          user_id: string | null;
+          id: string;
           username: string | null;
         };
         Insert: {
           avatar_url?: string | null;
           bio?: string | null;
           created_at?: string;
-          id?: number;
-          user_id?: string | null;
+          id: string;
           username?: string | null;
         };
         Update: {
           avatar_url?: string | null;
           bio?: string | null;
           created_at?: string;
-          id?: number;
-          user_id?: string | null;
+          id?: string;
           username?: string | null;
         };
         Relationships: [];
@@ -353,11 +353,10 @@ export type Database = {
           },
         ];
       };
-      user_inventory: {
+      user_items: {
         Row: {
           acquired_at: string;
           id: string;
-          is_equipped: boolean;
           item_id: string;
           quantity: number;
           user_id: string;
@@ -365,7 +364,6 @@ export type Database = {
         Insert: {
           acquired_at?: string;
           id?: string;
-          is_equipped?: boolean;
           item_id: string;
           quantity?: number;
           user_id: string;
@@ -373,7 +371,6 @@ export type Database = {
         Update: {
           acquired_at?: string;
           id?: string;
-          is_equipped?: boolean;
           item_id?: string;
           quantity?: number;
           user_id?: string;
@@ -390,21 +387,18 @@ export type Database = {
       };
       user_state: {
         Row: {
-          created_at: string;
+          heat_level: number;
           sparks_balance: number;
-          updated_at: string;
           user_id: string;
         };
         Insert: {
-          created_at?: string;
+          heat_level?: number;
           sparks_balance?: number;
-          updated_at?: string;
           user_id: string;
         };
         Update: {
-          created_at?: string;
+          heat_level?: number;
           sparks_balance?: number;
-          updated_at?: string;
           user_id?: string;
         };
         Relationships: [];
@@ -432,7 +426,14 @@ export type Database = {
       [_ in never]: never;
     };
     Functions: {
-      [_ in never]: never;
+      credit_completion_sparks: {
+        Args: { p_amount: number; p_session_id: string; p_user_id: string };
+        Returns: number;
+      };
+      purchase_item: {
+        Args: { p_item_id: string; p_request_id: string; p_user_id: string };
+        Returns: number;
+      };
     };
     Enums: {
       [_ in never]: never;

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "db:start": "pnpx supabase start",
     "db:stop": "pnpx supabase stop",
     "db:reset": "pnpx supabase db reset",
+    "db:migrate": "pnpx supabase migration up",
     "db:push": "pnpx supabase db push",
     "db:gentypes": "pnpx supabase gen types typescript --local > utils/supabase/types.ts",
     "prepare": "husky",

--- a/supabase/migrations/20260428204748_refactor_user_tables.sql
+++ b/supabase/migrations/20260428204748_refactor_user_tables.sql
@@ -1,0 +1,227 @@
+-- Refactor user-related tables:
+-- 1. Restructure profiles table (bigint PK → uuid PK referencing auth.users)
+-- 2. Rename user_inventory → user_items, drop is_equipped column
+-- 3. Add is_equippable to items table
+-- 4. Remove created_at/updated_at from user_state, add heat_level
+-- 5. Tighten RLS: user_items and user_state are read-only for clients
+-- 6. Auto-create profiles + user_state on signup via trigger
+-- 7. Update RPCs to reflect table/column changes
+
+-- ============================================================
+-- 1. RESTRUCTURE PROFILES
+-- ============================================================
+
+-- Drop the old profiles table (bigint PK, gen_random_uuid() default on user_id)
+drop policy if exists "Enable read access for all users" on public.profiles;
+drop table if exists public.profiles;
+
+create table public.profiles (
+  id uuid primary key references auth.users(id) on delete cascade,
+  username text unique,
+  bio text,
+  avatar_url text,
+  created_at timestamptz not null default now()
+);
+
+alter table public.profiles enable row level security;
+
+create policy "Anyone can view profiles"
+  on public.profiles for select
+  using (true);
+
+-- Users can update their own profile (no INSERT — trigger handles creation)
+create policy "Users can update own profile"
+  on public.profiles for update
+  using (auth.uid() = id);
+
+-- ============================================================
+-- 2. RENAME user_inventory → user_items + DROP is_equipped
+-- ============================================================
+
+-- Drop old RLS policies
+drop policy if exists "Users can view own user_inventory" on public.user_inventory;
+drop policy if exists "Users can insert own user_inventory" on public.user_inventory;
+drop policy if exists "Users can update own user_inventory" on public.user_inventory;
+drop policy if exists "Users can delete own user_inventory" on public.user_inventory;
+
+-- Rename table
+alter table public.user_inventory rename to user_items;
+
+-- Rename index and constraints for clarity
+alter index user_inventory_user_id_idx rename to user_items_user_id_idx;
+alter index user_inventory_pkey rename to user_items_pkey;
+alter index user_inventory_user_id_item_id_key rename to user_items_user_id_item_id_key;
+
+-- Drop is_equipped column (equippability is an item catalog property, not per-user state)
+alter table public.user_items drop column is_equipped;
+
+-- Client can only read their own items; all mutations go through RPCs
+create policy "Users can view own user_items"
+  on public.user_items for select
+  using (auth.uid() = user_id);
+
+-- ============================================================
+-- 3. ADD is_equippable TO ITEMS
+-- ============================================================
+
+alter table public.items
+  add column is_equippable boolean not null default false;
+
+-- ============================================================
+-- 4. CLEAN UP user_state: drop timestamps, add heat_level,
+--    tighten RLS to read-only
+-- ============================================================
+
+alter table public.user_state
+  drop column created_at,
+  drop column updated_at;
+
+alter table public.user_state
+  add column heat_level integer not null default 0;
+
+-- Drop overly permissive policies (INSERT/UPDATE/DELETE not needed by clients)
+drop policy if exists "Users can insert own user_state" on public.user_state;
+drop policy if exists "Users can update own user_state" on public.user_state;
+drop policy if exists "Users can delete own user_state" on public.user_state;
+
+-- SELECT policy already exists ("Users can view own user_state") — keep it
+
+-- ============================================================
+-- 5. AUTO-CREATE TRIGGER
+-- ============================================================
+
+create or replace function public.handle_new_user()
+returns trigger
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+begin
+  insert into public.profiles (id) values (new.id);
+  insert into public.user_state (user_id) values (new.id);
+  return new;
+end;
+$$;
+
+create trigger on_auth_user_created
+  after insert on auth.users
+  for each row execute function public.handle_new_user();
+
+-- ============================================================
+-- 6. UPDATE RPCs (remove updated_at refs, rename user_inventory)
+-- ============================================================
+
+create or replace function public.purchase_item(
+  p_user_id uuid,
+  p_item_id uuid,
+  p_request_id uuid
+)
+returns integer
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+declare
+  v_cost integer;
+  v_balance integer;
+  v_inserted integer;
+begin
+  select cost_sparks into v_cost
+  from public.items
+  where id = p_item_id and is_active = true
+  for share;
+
+  if not found or v_cost <= 0 then
+    return 0;
+  end if;
+
+  select sparks_balance into v_balance
+  from public.user_state
+  where user_id = p_user_id
+  for update;
+
+  if not found then
+    return 0;
+  end if;
+
+  if v_balance < v_cost then
+    return 0;
+  end if;
+
+  insert into public.spark_transactions (user_id, amount, reason, reference_id)
+  values (p_user_id, -v_cost, 'purchase', p_request_id)
+  on conflict (reference_id, reason) do nothing;
+
+  get diagnostics v_inserted = row_count;
+  if v_inserted = 0 then
+    return 0;
+  end if;
+
+  update public.user_state
+  set sparks_balance = sparks_balance - v_cost
+  where user_id = p_user_id;
+
+  insert into public.user_items (user_id, item_id, quantity)
+  values (p_user_id, p_item_id, 1)
+  on conflict (user_id, item_id)
+  do update set quantity = user_items.quantity + 1;
+
+  return v_cost;
+end;
+$$;
+
+create or replace function public.credit_completion_sparks(
+  p_user_id uuid,
+  p_session_id uuid,
+  p_amount integer
+)
+returns integer
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+begin
+  if p_amount <= 0 then
+    return 0;
+  end if;
+
+  if not exists (
+    select 1
+    from public.flame_sessions fs
+    where fs.id = p_session_id
+      and fs.user_id = p_user_id
+  ) then
+    return 0;
+  end if;
+
+  insert into public.spark_transactions (user_id, amount, reason, reference_id)
+  values (p_user_id, p_amount, 'completion', p_session_id)
+  on conflict (reference_id, reason) do nothing;
+
+  if not found then
+    return 0;
+  end if;
+
+  -- Atomic balance increment (user_state row guaranteed by signup trigger)
+  update public.user_state
+  set sparks_balance = sparks_balance + p_amount
+  where user_id = p_user_id;
+
+  -- Fallback for users created before the trigger existed
+  if not found then
+    insert into public.user_state (user_id, sparks_balance)
+    values (p_user_id, p_amount)
+    on conflict (user_id) do update
+    set sparks_balance = user_state.sparks_balance + p_amount;
+  end if;
+
+  return p_amount;
+end;
+$$;
+
+-- Re-revoke execute from client-facing roles (create or replace resets grants)
+revoke execute on function public.purchase_item(uuid, uuid, uuid)
+  from public, anon, authenticated;
+
+revoke execute on function public.credit_completion_sparks(uuid, uuid, integer)
+  from public, anon, authenticated;

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -13,17 +13,17 @@
     ('11111111-1111-1111-1111-111111111111', 'Exercise', 'time'),
     ('11111111-1111-1111-1111-111111111111', 'Read', 'count');
 
-  -- Test user state 
-  insert into user_state (user_id, sparks_balance)
-  values ('11111111-1111-1111-1111-111111111111', 42069);
+  -- Test user state (row auto-created by handle_new_user trigger)
+  update user_state set sparks_balance = 42069
+  where user_id = '11111111-1111-1111-1111-111111111111';
 
   -- Sample items
   insert into items (id, name, description, type, cost_sparks) values
     ('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', 'Sticky Note Pack', 'Open to get sticky notes to post on your wall', 'item', 100);
 
   -- Inventory entries for test user
-  insert into user_inventory (user_id, item_id, quantity, is_equipped) values
-    ('11111111-1111-1111-1111-111111111111', 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', 1, false);
+  insert into user_items (user_id, item_id, quantity) values
+    ('11111111-1111-1111-1111-111111111111', 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', 1);
 
   -- Sample spark transactions (earn, earn, spend)
   insert into spark_transactions (user_id, amount, reason) values


### PR DESCRIPTION
## Summary
- **Restructured `profiles` table**: Replaced bigint PK + separate `user_id` FK with uuid PK directly referencing `auth.users(id)`, matching the standard Supabase pattern
- **Renamed `user_inventory` → `user_items`**: Better reflects its role as a many-to-many relation between users and items. Removed `is_equipped` column (moved equippability concept to `items.is_equippable` as a catalog property)
- **Cleaned up `user_state`**: Removed redundant `created_at`/`updated_at` timestamps, added `heat_level` column
- **Tightened RLS policies**: `user_items` and `user_state` are now SELECT-only for clients — all mutations go through SECURITY DEFINER RPCs, closing the attack surface for direct client-side state manipulation
- **Added signup trigger**: `handle_new_user()` auto-creates `profiles` and `user_state` rows on `auth.users` insert, replacing the lazy-creation pattern
- **Updated RPCs**: `purchase_item` and `credit_completion_sparks` reflect table renames and removed `updated_at` references, with re-revoked execute permissions
- **Updated app code**: Renamed `UserInventory` → `UserItem`, `getUserInventory` → `getUserItems`, `getOrCreateUserState` → `getUserState`, fixed seed data
- **Added RLS guidelines to CLAUDE.md**

## Test plan
- [x] Migration applies cleanly on local Supabase (`db reset` passes)
- [x] Seed data inserts correctly with trigger-based auto-creation
- [x] Types regenerated and linter passes
- [x] Verify signup creates `profiles` + `user_state` rows automatically
- [ ] Verify sparks credit and purchase RPCs still function via server actions
- [ ] Verify profile badge displays sparks balance correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)