### PR TITLE
ref(db): Rename profiles table to user_profiles

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,8 @@ See @package.json for available scripts for this project.
 ## Database Migrations
 
 - **RLS Policy Principle of Least Privilege**: Before adding an INSERT, UPDATE, or DELETE RLS policy, consider whether the operation is performed by the client (via `createClientWithAuth`) or by the server (via SECURITY DEFINER RPCs / `createServiceClient`). If a table is only mutated by server-side RPCs, clients should only have a SELECT policy. SECURITY DEFINER functions bypass RLS, so they don't need client-facing write policies.
-- **Trigger-managed rows**: Tables like `profiles` and `user_state` that are auto-created by database triggers (SECURITY DEFINER) don't need client INSERT policies.
+- **Trigger-managed rows**: Tables like `user_profiles` and `user_state` that are auto-created by database triggers (SECURITY DEFINER) don't need client INSERT policies.
+- **Creating migrations**: Always use `pnpx supabase migration new <name>` to create migration files. Never create migration files manually.
 - **Applying migrations locally**: Use `pnpm db:migrate` to apply pending migrations to the local database. Never use `db:reset` to test migrations as it wipes all local data. `db:push` is for pushing to the remote/production database only.
 
 ## Workflow

--- a/lib/supabase/rows.ts
+++ b/lib/supabase/rows.ts
@@ -10,5 +10,6 @@ export type FlameSession =
 export type UserState = Database['public']['Tables']['user_state']['Row'];
 export type Item = Database['public']['Tables']['items']['Row'];
 export type UserItem = Database['public']['Tables']['user_items']['Row'];
+export type UserProfile = Database['public']['Tables']['user_profiles']['Row'];
 export type SparkTransaction =
   Database['public']['Tables']['spark_transactions']['Row'];

--- a/lib/supabase/types.ts
+++ b/lib/supabase/types.ts
@@ -255,30 +255,6 @@ export type Database = {
         };
         Relationships: [];
       };
-      profiles: {
-        Row: {
-          avatar_url: string | null;
-          bio: string | null;
-          created_at: string;
-          id: string;
-          username: string | null;
-        };
-        Insert: {
-          avatar_url?: string | null;
-          bio?: string | null;
-          created_at?: string;
-          id: string;
-          username?: string | null;
-        };
-        Update: {
-          avatar_url?: string | null;
-          bio?: string | null;
-          created_at?: string;
-          id?: string;
-          username?: string | null;
-        };
-        Relationships: [];
-      };
       spark_transactions: {
         Row: {
           amount: number;
@@ -384,6 +360,30 @@ export type Database = {
             referencedColumns: ['id'];
           },
         ];
+      };
+      user_profiles: {
+        Row: {
+          avatar_url: string | null;
+          bio: string | null;
+          created_at: string;
+          id: string;
+          username: string | null;
+        };
+        Insert: {
+          avatar_url?: string | null;
+          bio?: string | null;
+          created_at?: string;
+          id: string;
+          username?: string | null;
+        };
+        Update: {
+          avatar_url?: string | null;
+          bio?: string | null;
+          created_at?: string;
+          id?: string;
+          username?: string | null;
+        };
+        Relationships: [];
       };
       user_state: {
         Row: {

--- a/supabase/migrations/20260428213825_rename_profiles_to_user_profiles.sql
+++ b/supabase/migrations/20260428213825_rename_profiles_to_user_profiles.sql
@@ -1,0 +1,36 @@
+-- Rename profiles → user_profiles for consistency with other user tables
+-- (user_state, user_items, etc.)
+
+-- Drop existing RLS policies (they reference the old table name)
+drop policy if exists "Anyone can view profiles" on public.profiles;
+drop policy if exists "Users can update own profile" on public.profiles;
+
+-- Rename table
+alter table public.profiles rename to user_profiles;
+
+-- Rename indexes for clarity
+alter index profiles_pkey rename to user_profiles_pkey;
+alter index profiles_username_key rename to user_profiles_username_key;
+
+-- Recreate RLS policies with consistent naming
+create policy "Anyone can view user_profiles"
+  on public.user_profiles for select
+  using (true);
+
+create policy "Users can update own user_profile"
+  on public.user_profiles for update
+  using (auth.uid() = id);
+
+-- Update trigger function to reference new table name
+create or replace function public.handle_new_user()
+returns trigger
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+begin
+  insert into public.user_profiles (id) values (new.id);
+  insert into public.user_state (user_id) values (new.id);
+  return new;
+end;
+$$;


### PR DESCRIPTION
## Summary
- Renames `profiles` → `user_profiles` for consistency with other user-scoped tables (`user_state`, `user_items`)
- Updates indexes, RLS policies, and `handle_new_user()` trigger to reference the new table name
- Regenerates TypeScript types and adds `UserProfile` type alias
- Adds CLAUDE.md directive to always use `supabase migration new` for creating migrations

## Test plan
- [x] Migration applied cleanly via `pnpm db:migrate`
- [x] Types regenerated successfully
- [x] Lint and type check pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added migration creation directive specifying the required command format and explicitly forbidding manual migration file creation.

* **Chores**
  * Reorganized database schema structure with updates to TypeScript type definitions to reflect changes and maintain type safety across the codebase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->