### PR TITLE
chore: Remove redundant lint/format directive from CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,6 @@ See @package.json for available scripts for this project.
 
 ## Workflow
 - Create a new appropriately named branch before making changes
-- Run linter and formatter before committing
 - Regenerate types and run migrations after making DB changes
 - Keep commits as atomically scoped as possible to allow ease of reading history
 - If making a new PR, include a brief and well-structured summarization of your changes in the description


### PR DESCRIPTION
## Summary
- Removes the "Run linter and formatter before committing" workflow directive since git hooks (husky + lint-staged) now handle this automatically on every commit

## Test plan
- [x] Verified pre-commit hook runs biome check on staged files

🤖 Generated with [Claude Code](https://claude.com/claude-code)