### PR TITLE
ref(ui): Fetch user state in server layout instead of client

### DIFF
--- a/app/(app)/components/ProfileBadge.tsx
+++ b/app/(app)/components/ProfileBadge.tsx
@@ -19,7 +19,6 @@ import Link from 'next/link';
 import { useTranslations } from 'next-intl';
 import { useEffect, useRef, useState } from 'react';
 import { getFlameLevel } from '@/app/(app)/flames/utils/levels';
-import { getUserState } from '@/app/(app)/shop/actions';
 import {
   Popover,
   PopoverContent,
@@ -28,7 +27,8 @@ import {
 import { type LandingState, useSparkFlyover } from './SparkFlyover';
 
 interface ProfileBadgeProps {
-  username?: string;
+  username: string;
+  sparks: number;
   rankName?: string;
   level?: number;
   xp?: number;
@@ -36,7 +36,6 @@ interface ProfileBadgeProps {
 }
 
 const MOCK_DATA = {
-  username: 'Ash',
   rankName: 'Smokesniffer',
   level: 3,
   xp: 690,
@@ -155,34 +154,15 @@ function XPRing({ progress }: { progress: number }) {
   );
 }
 
-// ─── Skeleton ───────────────────────────────────────────────────────
-function ProfileBadgeSkeleton() {
-  return (
-    <div className="flex items-center rounded-full border border-border bg-muted/50 py-0.5 pl-0.5 pr-2.5">
-      <div className="relative mr-1.5 flex size-7 items-center justify-center">
-        <div className="flex size-5 items-center justify-center rounded-full bg-background">
-          <UserIcon className="size-2.5 text-muted-foreground" />
-        </div>
-      </div>
-      <div className="h-3.5 w-12 animate-pulse rounded bg-muted" />
-      <span className="mx-1.5 text-border">&middot;</span>
-      <div className="flex items-center gap-1">
-        <SparklesIcon className="size-3.5 text-muted-foreground" />
-        <div className="h-3.5 w-5 animate-pulse rounded bg-muted" />
-      </div>
-    </div>
-  );
-}
-
 // ─── Main component ─────────────────────────────────────────────────
 export function ProfileBadge({
-  username = MOCK_DATA.username,
+  username,
+  sparks,
   rankName = MOCK_DATA.rankName,
   level = MOCK_DATA.level,
   xp = MOCK_DATA.xp,
   xpToNext = MOCK_DATA.xpToNext,
 }: ProfileBadgeProps) {
-  const [sparks, setSparks] = useState<number | null>(null);
   const levelInfo = getFlameLevel(level);
   const xpProgress = xpToNext > 0 ? Math.min(1, Math.max(0, xp / xpToNext)) : 0;
   const { registerTarget, landingState, sparksBoost, resetBoost } =
@@ -191,44 +171,21 @@ export function ProfileBadge({
   const sparkRef = useRef<HTMLDivElement>(null);
   const { scale, flashActive } = useInflatingPulse(landingState);
 
-  useEffect(() => {
-    let cancelled = false;
-    async function fetchUserState() {
-      try {
-        const result = await getUserState();
-        if (cancelled) return;
-        setSparks(result.success ? result.data.sparks_balance : 0);
-      } catch {
-        if (!cancelled) setSparks(0);
-      }
-    }
-    fetchUserState();
-    return () => {
-      cancelled = true;
-    };
-  }, []);
-
   const prevServerSparks = useRef(sparks);
   useEffect(() => {
-    if (sparks !== null && sparks !== prevServerSparks.current) {
+    if (sparks !== prevServerSparks.current) {
       prevServerSparks.current = sparks;
       resetBoost();
     }
   }, [sparks, resetBoost]);
 
-  const effectiveSparks = (sparks ?? 0) + sparksBoost;
+  const effectiveSparks = sparks + sparksBoost;
 
-  const loaded = sparks !== null;
   useEffect(() => {
-    if (!loaded) return;
     registerTarget(sparkRef.current);
-  }, [registerTarget, loaded]);
+  }, [registerTarget]);
 
   const displayedSparks = getDisplayedSparks(effectiveSparks, landingState);
-
-  if (sparks === null) {
-    return <ProfileBadgeSkeleton />;
-  }
 
   return (
     <Popover>

--- a/app/(app)/components/TopBar.tsx
+++ b/app/(app)/components/TopBar.tsx
@@ -8,7 +8,12 @@ import { CreateButton } from '@/app/(app)/dashboard/components/CreateButton';
 import { NAV_ITEMS } from './nav-items';
 import { ProfileBadge } from './ProfileBadge';
 
-export function TopBar() {
+interface TopBarProps {
+  username: string;
+  sparks: number;
+}
+
+export function TopBar({ username, sparks }: TopBarProps) {
   const pathname = usePathname();
   const t = useTranslations('navigation');
 
@@ -53,7 +58,7 @@ export function TopBar() {
         <div className="flex items-center gap-2">
           <CreateButton />
           <div className="mx-1 h-5 w-px bg-border" />
-          <ProfileBadge />
+          <ProfileBadge username={username} sparks={sparks} />
         </div>
       </div>
 
@@ -66,7 +71,7 @@ export function TopBar() {
           <Image src="/logo.svg" alt="" width={20} height={20} />
           <span className="text-sm">Hibana</span>
         </Link>
-        <ProfileBadge />
+        <ProfileBadge username={username} sparks={sparks} />
       </div>
     </header>
   );

--- a/app/(app)/layout.tsx
+++ b/app/(app)/layout.tsx
@@ -2,16 +2,35 @@ import { BottomNav } from '@/app/(app)/components/BottomNav';
 import { SparkFlyoverProvider } from '@/app/(app)/components/SparkFlyover';
 import { TimezoneSync } from '@/app/(app)/components/TimezoneSync';
 import { TopBar } from '@/app/(app)/components/TopBar';
+import { createClientWithAuth } from '@/lib/supabase/server';
 
-export default function AppLayout({
+export default async function AppLayout({
   children,
 }: Readonly<{
   children: React.ReactNode;
 }>) {
+  const { supabase, user } = await createClientWithAuth();
+
+  const [profileResult, stateResult] = await Promise.all([
+    supabase
+      .from('user_profiles')
+      .select('username')
+      .eq('id', user.id)
+      .single(),
+    supabase
+      .from('user_states')
+      .select('sparks_balance')
+      .eq('user_id', user.id)
+      .single(),
+  ]);
+
+  const username = profileResult.data?.username ?? 'User';
+  const sparks = stateResult.data?.sparks_balance ?? 0;
+
   return (
     <main className="h-screen w-full">
       <SparkFlyoverProvider>
-        <TopBar />
+        <TopBar username={username} sparks={sparks} />
         <section className="h-full w-full pt-12 pb-24 md:pt-14 md:pb-0">
           {children}
         </section>

--- a/app/(app)/layout.tsx
+++ b/app/(app)/layout.tsx
@@ -24,6 +24,14 @@ export default async function AppLayout({
       .single(),
   ]);
 
+  if (profileResult.error)
+    console.error(
+      '[AppLayout] user_profiles query failed',
+      profileResult.error,
+    );
+  if (stateResult.error)
+    console.error('[AppLayout] user_states query failed', stateResult.error);
+
   const username = profileResult.data?.username ?? 'User';
   const sparks = stateResult.data?.sparks_balance ?? 0;
 


### PR DESCRIPTION
## Summary

- Moves ProfileBadge data fetching from a client-side `useEffect` + server action pattern to server-side fetching in `(app)/layout.tsx`
- The layout now fetches `user_profiles.username` and `user_states.sparks_balance` in parallel and passes them as props through TopBar → ProfileBadge
- Eliminates the loading skeleton flash on every navigation — data is available on first render
- Spark flyover animation and optimistic boost are fully preserved

## Changes

- **`app/(app)/layout.tsx`** — Made async, fetches user profile + state, passes props to TopBar
- **`app/(app)/components/TopBar.tsx`** — Accepts and forwards `username` and `sparks` props
- **`app/(app)/components/ProfileBadge.tsx`** — Removed client-side `getUserState()` fetch, `useState` for sparks, loading skeleton; accepts `sparks` as a required prop

## Test plan

- [x] Navigate to `/dashboard` — ProfileBadge shows username and sparks immediately (no skeleton flash)
- [x] Complete a flame session — spark particles fly in and count increments in real-time
- [x] After revalidation, sparks count reflects the new server value
- [x] New user with no username set shows "User" as fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * User profile data initialization moved server-side, occurring before component rendering to eliminate client-side data fetching operations.
  * Profile badge component updated to accept pre-loaded username and account balance information as input parameters instead of managing its own data fetching.
  * Removed skeleton loading indicator that was previously shown during profile data retrieval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->