### PR TITLE
fix(db): Backfill user_profiles for existing users

### DIFF
--- a/supabase/migrations/20260429010231_backfill_user_profiles.sql
+++ b/supabase/migrations/20260429010231_backfill_user_profiles.sql
@@ -1,0 +1,7 @@
+-- Backfill user_profiles rows for existing auth.users who were created
+-- before the on_auth_user_created trigger was added.
+
+insert into public.user_profiles (id)
+select id from auth.users
+where id not in (select id from public.user_profiles)
+on conflict (id) do nothing;


### PR DESCRIPTION
## Summary

- Adds a migration to insert `user_profiles` rows for all existing `auth.users` who were created before the `on_auth_user_created` trigger was added
- Uses `ON CONFLICT DO NOTHING` for idempotency

## Post-merge action required

Run `supabase db push` to apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue where existing user profiles were not being properly initialized.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->