### PR TITLE
feat(test): Add GitHub reporter for inline CI annotations

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -22,7 +22,9 @@ export default defineConfig({
   /* Opt out of parallel tests on CI. */
   workers: process.env.CI ? 1 : undefined,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
-  reporter: 'html',
+  reporter: process.env.CI
+    ? [['github'], ['html', { open: 'never' }]]
+    : [['html']],
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Base URL to use in actions like `await page.goto('')`. */

--- a/tests/seed.spec.ts
+++ b/tests/seed.spec.ts
@@ -1,7 +1,7 @@
 import { test } from '@playwright/test';
 
 test.describe('Test group', () => {
-  test('seed', async ({ page }) => {
+  test('seed', async () => {
     // generate code here.
   });
 });


### PR DESCRIPTION
## Summary
- Adds Playwright's built-in `github` reporter in CI for inline failure annotations on PRs
- Keeps `html` reporter for detailed artifact reports (with `open: 'never'` in CI)
- Fixes unused parameter lint error in `seed.spec.ts`

## Test plan
- [ ] Verify CI workflow runs and produces annotations on test failures
- [ ] Verify HTML report artifact is still uploaded


🤖 Generated with [Claude Code](https://claude.com/claude-code)