### PR TITLE
feat(ci): Add lint and type check workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,31 @@
+name: Lint & Type Check
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+    branches: [main, master]
+
+jobs:
+  lint:
+    timeout-minutes: 10
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Enable pnpm via corepack
+        run: corepack enable
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: lts/*
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Lint
+        run: pnpm lint
+
+      - name: Type check
+        run: pnpm tsc --noEmit

--- a/tests/lint-test.ts
+++ b/tests/lint-test.ts
@@ -1,0 +1,7 @@
+// Intentional lint error: unused variable
+const unusedVariable = 'this should fail lint';
+
+// Intentional type error: assigning string to number
+const count: number = 'not a number';
+
+export {};

--- a/tests/lint-test.ts
+++ b/tests/lint-test.ts
@@ -1,7 +1,0 @@
-// Intentional lint error: unused variable
-const unusedVariable = 'this should fail lint';
-
-// Intentional type error: assigning string to number
-const count: number = 'not a number';
-
-export {};


### PR DESCRIPTION
## Summary
- Adds a dedicated CI workflow for `biome check` and `tsc --noEmit`
- Runs in ~30s, providing fast feedback on code quality independent of the Playwright E2E pipeline
- Triggers on the same events as the Playwright workflow (push to main/master, PRs)

## Test plan
- [x] Verify workflow passes on clean code
- [x] Verify workflow catches lint errors (e.g., introduce an unused import)
- [x] Verify workflow catches type errors (e.g., introduce a type mismatch)


🤖 Generated with [Claude Code](https://claude.com/claude-code)