### PR TITLE
feat(ci): Add path filtering to Playwright workflow

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1,9 +1,45 @@
 name: Playwright Tests
 on:
   push:
-    branches: [ main, master ]
+    branches: [main, master]
+    paths:
+      - 'app/**'
+      - 'components/**'
+      - 'lib/**'
+      - 'messages/**'
+      - 'public/**'
+      - 'supabase/migrations/**'
+      - 'supabase/config.toml'
+      - 'supabase/seed.sql'
+      - 'tests/**'
+      - 'next.config.ts'
+      - 'tsconfig.json'
+      - 'tailwind.config.ts'
+      - 'postcss.config.mjs'
+      - 'playwright.config.ts'
+      - 'package.json'
+      - 'pnpm-lock.yaml'
+      - 'global.d.ts'
   pull_request:
-    branches: [ main, master ]
+    branches: [main, master]
+    paths:
+      - 'app/**'
+      - 'components/**'
+      - 'lib/**'
+      - 'messages/**'
+      - 'public/**'
+      - 'supabase/migrations/**'
+      - 'supabase/config.toml'
+      - 'supabase/seed.sql'
+      - 'tests/**'
+      - 'next.config.ts'
+      - 'tsconfig.json'
+      - 'tailwind.config.ts'
+      - 'postcss.config.mjs'
+      - 'playwright.config.ts'
+      - 'package.json'
+      - 'pnpm-lock.yaml'
+      - 'global.d.ts'
 jobs:
   test:
     timeout-minutes: 60


### PR DESCRIPTION
## Summary
- Playwright E2E tests now only trigger when relevant files change
- Skips expensive Supabase + build + test pipeline for docs-only or config-only changes
- Updated branch protection: only `lint` is required (always runs), `test` provides signal when triggered but won't block non-app PRs

### Paths that trigger E2E tests
- Application code: `app/**`, `components/**`, `lib/**`
- i18n: `messages/**`
- Assets: `public/**`
- Database: `supabase/migrations/**`, `supabase/config.toml`, `supabase/seed.sql`
- Tests: `tests/**`
- Build config: `next.config.ts`, `tsconfig.json`, `tailwind.config.ts`, `postcss.config.mjs`, `playwright.config.ts`, `global.d.ts`
- Dependencies: `package.json`, `pnpm-lock.yaml`

### Paths that do NOT trigger E2E tests
- `README.md`, `CLAUDE.md`, `.github/**`, `.claude/**`, `.vscode/**`, `.husky/**`, `biome.json`, etc.

## Test plan
- [ ] PR touching only `README.md` should not trigger Playwright workflow
- [ ] PR touching `app/**` files should trigger Playwright workflow
- [ ] Lint workflow still runs on all PRs regardless of paths


🤖 Generated with [Claude Code](https://claude.com/claude-code)