### PR TITLE
chore(tooling): Add workspace Zed config for Biome formatting

### DIFF
--- a/.zed/settings.json
+++ b/.zed/settings.json
@@ -1,0 +1,34 @@
+{
+  "format_on_save": "on",
+  "formatter": {
+    "language_server": { "name": "biome" }
+  },
+  "code_actions_on_format": {
+    "source.fixAll.biome": true,
+    "source.organizeImports.biome": true
+  },
+  "languages": {
+    "JavaScript": {
+      "formatter": { "language_server": { "name": "biome" } }
+    },
+    "TypeScript": {
+      "formatter": { "language_server": { "name": "biome" } }
+    },
+    "TSX": {
+      "formatter": { "language_server": { "name": "biome" } }
+    },
+    "JSX": {
+      "formatter": { "language_server": { "name": "biome" } }
+    },
+    "JSON": {
+      "formatter": { "language_server": { "name": "biome" } }
+    },
+    "JSONC": {
+      "formatter": { "language_server": { "name": "biome" } }
+    },
+    "CSS": {
+      "formatter": { "language_server": { "name": "biome" } }
+    }
+  },
+  "prettier": { "allowed": false }
+}


### PR DESCRIPTION
## Summary
- Adds `.zed/settings.json` so Zed editors in this workspace use Biome as the formatter on save for JS/TS/JSX/TSX/JSON/JSONC/CSS.
- Enables `source.fixAll.biome` and `source.organizeImports.biome` as format-time code actions, matching the workspace's `biome.json` (which has `assist.actions.source.organizeImports: on`).
- Disables Prettier in this workspace to prevent fallback formatting that would conflict with `biome.json`.

## Why
Zed doesn't auto-detect `biome.json` — without explicit settings, format-on-save was applying default/Prettier-style rules that disagreed with the project's Biome config. Committing the config to the repo makes Biome the default for everyone opening this project in Zed.

## Requirements
- Contributors using Zed need the **Biome** extension installed (`cmd-shift-x` → "Biome"). The Biome LSP picks up the workspace `biome.json` and the locally installed `@biomejs/biome` binary automatically.

## Test plan
- [x] Open a `.ts`/`.tsx` file, save — formats to 2-space indent + single quotes per `biome.json`
- [x] Unused imports get removed on save (organize imports)
- [x] `.json` file saves with 2-space indent

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Configured automatic code formatting with Biome for JavaScript, TypeScript, and JSON file types, including auto-fixing and import organization functionality.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/0Calories/hibana/pull/240)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->