### PR TITLE
refactor(ui): Extract showcase flame components to marketing bundle

### DIFF
--- a/app/(marketing)/components/FlameShowcase.tsx
+++ b/app/(marketing)/components/FlameShowcase.tsx
@@ -3,28 +3,52 @@
 import { motion, useInView, useReducedMotion } from 'framer-motion';
 import { useTranslations } from 'next-intl';
 import { useRef } from 'react';
-import { EffectsRenderer } from '@/app/(app)/flames/components/flame-card/effects/EffectsRenderer';
-import { FlameRenderer } from '@/app/(app)/flames/components/flame-card/effects/FlameRenderer';
-import { FLAME_REGISTRY } from '@/app/(app)/flames/components/flame-card/flames';
-import { FLAME_HEX_COLORS } from '@/app/(app)/flames/utils/colors';
-import { FLAME_LEVELS } from '@/app/(app)/flames/utils/levels';
 import { ShowcaseFuelBar } from './ShowcaseFuelBar';
+import {
+  REVEALED_LEVEL_COUNT,
+  SHOWCASE_LEVELS,
+  type ShowcaseColors,
+} from './showcase/colors';
+import { ShowcaseFlame } from './showcase/Flames';
 
 const EASE_OUT_EXPO = [0.21, 0.47, 0.32, 0.98] as const;
 
-const SHOWCASE_COLORS = [
-  FLAME_HEX_COLORS.rose,
-  FLAME_HEX_COLORS.orange,
-  FLAME_HEX_COLORS.amber,
-  FLAME_HEX_COLORS.green,
-  FLAME_HEX_COLORS.sky,
-  FLAME_HEX_COLORS.indigo,
-  FLAME_HEX_COLORS.fuchsia,
-  FLAME_HEX_COLORS.blue,
-] as const;
-
-// Only reveal the first 3 flame shapes — the rest are a surprise
-const REVEALED_COUNT = 3;
+function MysteryGlyph({
+  colors,
+  size = 'lg',
+  label,
+}: {
+  colors: ShowcaseColors;
+  size?: 'sm' | 'lg';
+  label: string;
+}) {
+  const dim = size === 'lg' ? 'h-10 w-10' : 'h-8 w-8';
+  const text = size === 'lg' ? 'text-sm' : 'text-xs';
+  return (
+    <div className="relative flex h-full w-full items-center justify-center">
+      {size === 'lg' && (
+        <div
+          className="absolute h-12 w-12 rounded-full blur-xl"
+          style={{ backgroundColor: `${colors.medium}15` }}
+        />
+      )}
+      <div
+        className={`flex ${dim} items-center justify-center rounded-full border`}
+        style={{
+          borderColor: `${colors.medium}20`,
+          backgroundColor: `${colors.medium}08`,
+        }}
+      >
+        <span
+          className={`${text} font-bold`}
+          style={{ color: `${colors.medium}40` }}
+        >
+          {label}
+        </span>
+      </div>
+    </div>
+  );
+}
 
 export function FlameShowcase() {
   const ref = useRef<HTMLDivElement>(null);
@@ -39,10 +63,10 @@ export function FlameShowcase() {
       </div>
 
       {/* Desktop / tablet grid */}
-      <div className="hidden sm:grid sm:grid-cols-4 lg:grid-cols-8 gap-4">
-        {FLAME_LEVELS.map((level, i) => {
-          const revealed = i < REVEALED_COUNT;
-          const colors = SHOWCASE_COLORS[i];
+      <div className="hidden gap-4 sm:grid sm:grid-cols-4 lg:grid-cols-8">
+        {SHOWCASE_LEVELS.map((level, i) => {
+          const revealed = i < REVEALED_LEVEL_COUNT;
+          const colors = level.colors;
 
           return (
             <motion.div
@@ -58,40 +82,17 @@ export function FlameShowcase() {
             >
               <div className="relative mb-3 flex h-28 w-20 items-center justify-center">
                 {revealed ? (
-                  <>
-                    <FlameRenderer
-                      state="burning"
-                      level={level.level}
-                      colors={colors}
-                      className="h-24 w-20"
-                    />
-                    <EffectsRenderer
-                      effects={FLAME_REGISTRY[level.level].effects}
-                      state="paused"
-                      colors={colors}
-                    />
-                  </>
+                  <ShowcaseFlame
+                    level={level.level}
+                    colors={colors}
+                    className="h-24 w-20"
+                  />
                 ) : (
-                  <div className="relative flex h-full w-full items-center justify-center">
-                    <div
-                      className="absolute h-12 w-12 rounded-full blur-xl"
-                      style={{ backgroundColor: `${colors.medium}15` }}
-                    />
-                    <div
-                      className="flex h-10 w-10 items-center justify-center rounded-full border"
-                      style={{
-                        borderColor: `${colors.medium}20`,
-                        backgroundColor: `${colors.medium}08`,
-                      }}
-                    >
-                      <span
-                        className="text-sm font-bold"
-                        style={{ color: `${colors.medium}40` }}
-                      >
-                        {t('mysteryLabel')}
-                      </span>
-                    </div>
-                  </div>
+                  <MysteryGlyph
+                    colors={colors}
+                    size="lg"
+                    label={t('mysteryLabel')}
+                  />
                 )}
               </div>
               <span
@@ -118,11 +119,11 @@ export function FlameShowcase() {
       </div>
 
       {/* Mobile: scrollable row */}
-      <div className="sm:hidden -my-16">
+      <div className="-my-16 sm:hidden">
         <div className="flex snap-x snap-mandatory gap-6 overflow-x-scroll overflow-y-hidden px-2 pt-16 pb-4">
-          {FLAME_LEVELS.map((level, i) => {
-            const revealed = i < REVEALED_COUNT;
-            const colors = SHOWCASE_COLORS[i];
+          {SHOWCASE_LEVELS.map((level, i) => {
+            const revealed = i < REVEALED_LEVEL_COUNT;
+            const colors = level.colors;
 
             return (
               <motion.div
@@ -135,40 +136,21 @@ export function FlameShowcase() {
                   delay: i * 0.06,
                   ease: EASE_OUT_EXPO,
                 }}
-                className="flex shrink-0 snap-center flex-col items-center"
+                className="w-18 flex shrink-0 snap-center flex-col items-center"
               >
-                <div className="relative mb-3 flex h-24 w-18 items-center justify-center">
+                <div className="w-18 relative mb-3 flex h-24 items-center justify-center">
                   {revealed ? (
-                    <>
-                      <FlameRenderer
-                        state="burning"
-                        level={level.level}
-                        colors={colors}
-                        className="h-20 w-16"
-                      />
-                      <EffectsRenderer
-                        effects={FLAME_REGISTRY[level.level].effects}
-                        state="paused"
-                        colors={colors}
-                      />
-                    </>
+                    <ShowcaseFlame
+                      level={level.level}
+                      colors={colors}
+                      className="h-20 w-16"
+                    />
                   ) : (
-                    <div className="relative flex h-full w-full items-center justify-center">
-                      <div
-                        className="flex h-8 w-8 items-center justify-center rounded-full border"
-                        style={{
-                          borderColor: `${colors.medium}20`,
-                          backgroundColor: `${colors.medium}08`,
-                        }}
-                      >
-                        <span
-                          className="text-xs font-bold"
-                          style={{ color: `${colors.medium}40` }}
-                        >
-                          {t('mysteryLabel')}
-                        </span>
-                      </div>
-                    </div>
+                    <MysteryGlyph
+                      colors={colors}
+                      size="sm"
+                      label={t('mysteryLabel')}
+                    />
                   )}
                 </div>
                 <span

--- a/app/(marketing)/components/ShowcaseFuelBar.tsx
+++ b/app/(marketing)/components/ShowcaseFuelBar.tsx
@@ -4,8 +4,7 @@ import { motion, useInView, useReducedMotion } from 'framer-motion';
 import { Fuel } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 import { useRef } from 'react';
-import { FuelDroplets } from '@/app/(app)/flames/components/FuelDroplets';
-import { SmokePuffs } from '@/app/(app)/flames/components/SmokePuffs';
+import { FuelDroplets, SmokePuffs } from './showcase/FuelBarParticles';
 
 /**
  * Visual-only fuel bar for the marketing page.

--- a/app/(marketing)/components/showcase/Flames.tsx
+++ b/app/(marketing)/components/showcase/Flames.tsx
@@ -1,0 +1,93 @@
+import type { ShowcaseColors } from './colors';
+
+interface FlameProps {
+  colors: ShowcaseColors;
+}
+
+export function WispFlame({ colors }: FlameProps) {
+  return (
+    <>
+      <circle cx="50" cy="60" r="20" fill={colors.dark} opacity={0.5} />
+      <circle cx="50" cy="60" r="14" fill={colors.medium} opacity={0.7} />
+      <circle cx="50" cy="60" r="8" fill={colors.light} />
+      <circle cx="50" cy="60" r="4" fill="white" opacity={0.8} />
+    </>
+  );
+}
+
+export function CandleFlame({ colors }: FlameProps) {
+  return (
+    <>
+      {/* Candle body */}
+      <rect x="44" y="70" width="12" height="25" fill="#8B7355" rx="1" />
+      <rect x="42" y="68" width="16" height="4" fill="#A08060" rx="1" />
+      <ellipse cx="50" cy="95" rx="14" ry="4" fill="#6B5344" />
+      <rect x="49" y="62" width="2" height="10" fill="#333" />
+      {/* Flame */}
+      <polygon
+        points="50,15 65,55 58,68 42,68 35,55"
+        fill={colors.dark}
+        opacity={0.8}
+      />
+      <polygon
+        points="50,25 60,52 55,63 45,63 40,52"
+        fill={colors.medium}
+        opacity={0.9}
+      />
+      <polygon points="50,35 55,50 52,60 48,60 45,50" fill={colors.light} />
+    </>
+  );
+}
+
+export function TorchFlame({ colors }: FlameProps) {
+  return (
+    <>
+      {/* Torch handle */}
+      <polygon points="42,65 58,65 54,98 46,98" fill="#5D4037" />
+      <polygon points="44,65 56,65 53,98 47,98" fill="#6D4C41" />
+      <ellipse cx="50" cy="65" rx="12" ry="5" fill="#4E342E" />
+      <ellipse cx="50" cy="63" rx="10" ry="4" fill="#3E2723" />
+      {/* Flame */}
+      <polygon
+        points="50,5 75,50 65,65 35,65 25,50"
+        fill={colors.dark}
+        opacity={0.8}
+      />
+      <polygon
+        points="50,15 68,48 60,60 40,60 32,48"
+        fill={colors.medium}
+        opacity={0.9}
+      />
+      <polygon points="50,25 58,45 54,55 46,55 42,45" fill={colors.light} />
+    </>
+  );
+}
+
+const FLAME_BY_LEVEL: Record<number, (props: FlameProps) => React.ReactNode> = {
+  1: WispFlame,
+  2: CandleFlame,
+  3: TorchFlame,
+};
+
+export function ShowcaseFlame({
+  level,
+  colors,
+  className,
+}: {
+  level: number;
+  colors: ShowcaseColors;
+  className?: string;
+}) {
+  const Component = FLAME_BY_LEVEL[level];
+  if (!Component) return null;
+  return (
+    <svg
+      viewBox="0 0 100 100"
+      className={className}
+      aria-hidden="true"
+      role="img"
+    >
+      <Component colors={colors} />
+    </svg>
+  );
+}

--- a/app/(marketing)/components/showcase/FuelBarParticles.tsx
+++ b/app/(marketing)/components/showcase/FuelBarParticles.tsx
@@ -1,0 +1,100 @@
+'use client';
+
+import { motion, useReducedMotion } from 'framer-motion';
+
+// Deterministic seed values so server and client render identically.
+// Mirrors the look of the in-app FuelDroplets/SmokePuffs without dragging the
+// app-side particle engine into the marketing bundle.
+
+const DROPLETS = [
+  { size: 2.3, delay: 0.0, duration: 1.4, drift: -2 },
+  { size: 2.6, delay: 0.3, duration: 1.5, drift: 1 },
+  { size: 2.1, delay: 0.6, duration: 1.3, drift: -1 },
+  { size: 2.8, delay: 0.9, duration: 1.6, drift: 2 },
+  { size: 2.4, delay: 1.1, duration: 1.4, drift: 0 },
+] as const;
+
+const PUFFS = [
+  { size: 3.5, delay: 0.0, duration: 2.0, drift: -5, blur: 1.8, peak: 0.28 },
+  { size: 4.2, delay: 0.4, duration: 2.3, drift: 4, blur: 2.2, peak: 0.32 },
+  { size: 3.8, delay: 0.7, duration: 2.1, drift: -3, blur: 1.6, peak: 0.24 },
+  { size: 5.0, delay: 1.0, duration: 2.5, drift: 6, blur: 2.6, peak: 0.36 },
+  { size: 3.2, delay: 1.3, duration: 1.9, drift: -2, blur: 1.5, peak: 0.22 },
+  { size: 4.6, delay: 1.6, duration: 2.4, drift: 5, blur: 2.4, peak: 0.3 },
+  { size: 3.6, delay: 1.9, duration: 2.0, drift: -4, blur: 1.7, peak: 0.26 },
+] as const;
+
+export function FuelDroplets({ className }: { className?: string }) {
+  const shouldReduceMotion = useReducedMotion();
+  if (shouldReduceMotion) return null;
+
+  return (
+    <>
+      {DROPLETS.map((d, i) => (
+        <motion.div
+          // biome-ignore lint/suspicious/noArrayIndexKey: static deterministic list
+          key={i}
+          className={`absolute ${className ?? ''}`}
+          style={{
+            width: d.size,
+            height: d.size + 1,
+            left: -d.size / 2,
+            top: '50%',
+            borderRadius: '40% 40% 50% 50%',
+          }}
+          initial={{ opacity: 0, y: 0, x: 0, scale: 1 }}
+          animate={{
+            opacity: [0, 0.7, 0.5, 0],
+            y: [0, 6, 16, 24],
+            x: [0, d.drift * 0.5, d.drift],
+            scale: [1, 1, 0.8, 0.4],
+          }}
+          transition={{
+            duration: d.duration,
+            delay: d.delay,
+            repeat: Number.POSITIVE_INFINITY,
+            ease: 'easeIn',
+          }}
+        />
+      ))}
+    </>
+  );
+}
+
+export function SmokePuffs({ color }: { color: string }) {
+  const shouldReduceMotion = useReducedMotion();
+  if (shouldReduceMotion) return null;
+
+  return (
+    <>
+      {PUFFS.map((p, i) => (
+        <motion.div
+          // biome-ignore lint/suspicious/noArrayIndexKey: static deterministic list
+          key={i}
+          className="absolute rounded-full"
+          style={{
+            width: p.size,
+            height: p.size,
+            left: -p.size / 2,
+            top: '50%',
+            filter: `blur(${p.blur}px)`,
+            background: color,
+          }}
+          initial={{ opacity: 0, y: 0, x: 0, scale: 1 }}
+          animate={{
+            opacity: [0, p.peak, p.peak * 0.5, 0],
+            y: [0, -8, -18, -28],
+            x: [0, p.drift * 0.3, p.drift * 0.7, p.drift],
+            scale: [0.6, 1, 1.4, 1.8],
+          }}
+          transition={{
+            duration: p.duration,
+            delay: p.delay,
+            repeat: Number.POSITIVE_INFINITY,
+            ease: 'easeOut',
+          }}
+        />
+      ))}
+    </>
+  );
+}

--- a/app/(marketing)/components/showcase/colors.ts
+++ b/app/(marketing)/components/showcase/colors.ts
@@ -1,0 +1,58 @@
+export interface ShowcaseColors {
+  light: string;
+  medium: string;
+  dark: string;
+}
+
+export interface ShowcaseLevel {
+  level: number;
+  name: string;
+  colors: ShowcaseColors;
+}
+
+// Tailwind 400/500/600 hex values for the 8 flame tiers shown on the marketing
+// page. Kept local to the marketing bundle so we don't pull from app/(app).
+export const SHOWCASE_LEVELS: ShowcaseLevel[] = [
+  {
+    level: 1,
+    name: 'Wisp',
+    colors: { light: '#fda4af', medium: '#f43f5e', dark: '#e11d48' }, // rose
+  },
+  {
+    level: 2,
+    name: 'Candle',
+    colors: { light: '#fdba74', medium: '#f97316', dark: '#ea580c' }, // orange
+  },
+  {
+    level: 3,
+    name: 'Torch',
+    colors: { light: '#fcd34d', medium: '#f59e0b', dark: '#d97706' }, // amber
+  },
+  {
+    level: 4,
+    name: 'Bonfire',
+    colors: { light: '#86efac', medium: '#22c55e', dark: '#16a34a' }, // green
+  },
+  {
+    level: 5,
+    name: 'Blaze',
+    colors: { light: '#7dd3fc', medium: '#0ea5e9', dark: '#0284c7' }, // sky
+  },
+  {
+    level: 6,
+    name: 'Inferno',
+    colors: { light: '#a5b4fc', medium: '#6366f1', dark: '#4f46e5' }, // indigo
+  },
+  {
+    level: 7,
+    name: 'Star',
+    colors: { light: '#f0abfc', medium: '#d946ef', dark: '#c026d3' }, // fuchsia
+  },
+  {
+    level: 8,
+    name: 'Supernova',
+    colors: { light: '#93c5fd', medium: '#3b82f6', dark: '#2563eb' }, // blue
+  },
+];
+
+export const REVEALED_LEVEL_COUNT = 3;


### PR DESCRIPTION
## Summary
Refactored the flame showcase on the marketing page to use self-contained, lightweight SVG-based flame components instead of importing from the app bundle. This reduces the marketing bundle size and decouples marketing-specific UI from the main application.

## Key Changes
- **New showcase module** (`app/(marketing)/components/showcase/`):
  - `colors.ts`: Centralized color definitions and level metadata for the 8 showcase flame tiers
  - `Flames.tsx`: Three lightweight SVG-based flame components (WispFlame, CandleFlame, TorchFlame) that render deterministically without animation dependencies
  - `FuelBarParticles.tsx`: Deterministic particle animations (FuelDroplets, SmokePuffs) with seeded values for consistent server/client rendering

- **Updated FlameShowcase.tsx**:
  - Removed imports from `app/(app)/flames` (EffectsRenderer, FlameRenderer, FLAME_REGISTRY, color/level utilities)
  - Replaced with imports from new local `showcase/` module
  - Extracted `MysteryGlyph` component to reduce duplication between desktop and mobile layouts
  - Simplified flame rendering to use `ShowcaseFlame` wrapper component
  - Improved Tailwind class ordering for consistency

- **Updated ShowcaseFuelBar.tsx**:
  - Replaced imports of FuelDroplets and SmokePuffs from app bundle with local showcase module imports

## Implementation Details
- Showcase flames are static SVG illustrations (no animation) that match the visual style of the app's flame system
- Particle animations use deterministic seed values to ensure identical server and client rendering
- Color system uses Tailwind 400/500/600 hex values, kept local to avoid app bundle dependencies
- `REVEALED_LEVEL_COUNT` constant controls how many flame shapes are shown vs. hidden as "mystery" items

https://claude.ai/code/session_01XxbEiWXGCgbdKSG2H3Tx76