### PR TITLE
fix(db): Tighten RLS policies on spark_transactions

### DIFF
--- a/supabase/migrations/20260517214250_tighten_spark_transactions_rls.sql
+++ b/supabase/migrations/20260517214250_tighten_spark_transactions_rls.sql
@@ -1,0 +1,15 @@
+-- Tighten RLS policies on spark_transactions: SELECT-only for clients.
+--
+-- spark_transactions is mutated only by SECURITY DEFINER RPCs
+-- (purchase_item, credit_completion_sparks). Those bypass RLS, so the
+-- client-facing INSERT/UPDATE/DELETE policies are unnecessary attack
+-- surface. Drop them and keep SELECT so users can read their own ledger.
+
+drop policy if exists "Users can insert own spark_transactions"
+  on public.spark_transactions;
+
+drop policy if exists "Users can update own spark_transactions"
+  on public.spark_transactions;
+
+drop policy if exists "Users can delete own spark_transactions"
+  on public.spark_transactions;


### PR DESCRIPTION
Drop client-facing INSERT/UPDATE/DELETE policies on spark_transactions.
The table is only mutated by SECURITY DEFINER RPCs (purchase_item,
credit_completion_sparks) which bypass RLS, so SELECT-only is sufficient
for clients and reduces unnecessary attack surface.

Closes #208

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated transaction access policies for stricter enforcement. Users can still view their transactions, but modifications are now processed server-side only.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/0Calories/hibana/pull/246?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->