### PR TITLE
fix(db): drop waitlist table

### DIFF
--- a/lib/supabase/types.ts
+++ b/lib/supabase/types.ts
@@ -453,24 +453,6 @@ export type Database = {
         }
         Relationships: []
       }
-      waitlist: {
-        Row: {
-          created_at: string
-          email: string
-          id: string
-        }
-        Insert: {
-          created_at?: string
-          email: string
-          id?: string
-        }
-        Update: {
-          created_at?: string
-          email?: string
-          id?: string
-        }
-        Relationships: []
-      }
     }
     Views: {
       [_ in never]: never

--- a/supabase/migrations/20260518203852_drop_waitlist_table.sql
+++ b/supabase/migrations/20260518203852_drop_waitlist_table.sql
@@ -1,0 +1,1 @@
+drop table if exists public.waitlist;


### PR DESCRIPTION
## Summary
- Drops the `public.waitlist` Supabase table (and its RLS policy) now that waitlist signups are handled via Resend Audiences.
- Regenerates `lib/supabase/types.ts` so the `waitlist` row type is removed.

Data has already been backed up and migrated to Resend.

## Dependency
Stacked on top of #244 (Resend integration). That PR must land first so the application is no longer writing to `public.waitlist` when this migration runs. GitHub will retarget this PR's base to `master` automatically once #244 merges.

## Test plan
- [x] `pnpm db:migrate` applies the migration cleanly against the local Supabase instance
- [x] `pnpm db:types` regenerates without the `waitlist` table type
- [x] `tsc --noEmit` passes — no remaining references to the dropped type
- [ ] CI migration validation passes
- [ ] After merge, verify the table is gone in production

🤖 Generated with [Claude Code](https://claude.com/claude-code)