### PR TITLE
fix(ui): Use document.cookie in TimezoneSync for older browsers

### DIFF
--- a/app/(app)/components/TimezoneSync.tsx
+++ b/app/(app)/components/TimezoneSync.tsx
@@ -5,16 +5,16 @@ import { useEffect } from 'react';
 export function TimezoneSync() {
   useEffect(() => {
     const tz = Intl.DateTimeFormat().resolvedOptions().timeZone;
-    cookieStore.get('timezone').then((cookie) => {
-      if (cookie?.value !== tz) {
-        cookieStore.set({
-          name: 'timezone',
-          value: tz,
-          path: '/',
-          sameSite: 'lax',
-        });
-      }
-    });
+    const current = document.cookie
+      .split('; ')
+      .find((c) => c.startsWith('timezone='))
+      ?.slice('timezone='.length);
+    if (current !== tz) {
+      // IANA names only contain cookie-safe characters; written raw on purpose
+      // because the server reads the value without decoding (lib/timezone.ts).
+      // biome-ignore lint/suspicious/noDocumentCookie: intentional fallback for browsers without Cookie Store API
+      document.cookie = `timezone=${tz}; path=/; max-age=31536000; samesite=lax`;
+    }
   }, []);
 
   return null;

--- a/tests/login.spec.ts
+++ b/tests/login.spec.ts
@@ -15,5 +15,9 @@ test.describe('login (authenticated)', () => {
   }) => {
     await page.goto('/dashboard');
     await expect(page).toHaveURL('/dashboard');
+
+    const cookies = await page.context().cookies();
+    const tzCookie = cookies.find((c) => c.name === 'timezone');
+    expect(tzCookie?.value).toBeTruthy();
   });
 });


### PR DESCRIPTION
## Problem

`TimezoneSync` writes the user's IANA timezone into a `timezone` cookie that the server relies on for **all** date logic (which day a schedule applies to, what "today" is). It did this via the global `cookieStore` — the Cookie Store API — with **no feature detection**.

That API only exists in Chromium 87+, Safari 18.4+ (March 2025), and recent Firefox. On any older engine (e.g. Safari 17 on macOS Ventura, which can't upgrade to Safari 18), `cookieStore` is undefined, the `useEffect` throws a `ReferenceError`, and since the `(app)` route group has no `error.tsx`, the error propagates to the root `global-error.tsx` — **crashing the entire authenticated app to the global error screen on mount** for those users.

CI never caught this because Playwright's bundled engines are all new enough to have `cookieStore`.

## Fix

Replace the Cookie Store API with `document.cookie` (universally supported, synchronous):

- Reads the current `timezone` cookie by parsing `document.cookie`.
- Writes the raw IANA value (no `encodeURIComponent` — the server reads it without decoding, and IANA names only contain cookie-safe characters).
- Same attributes as before (`path=/`, `samesite=lax`); adds `max-age=31536000` (1 year) in place of the Cookie Store session-scoped default.

A `biome-ignore lint/suspicious/noDocumentCookie` comment documents why the lint suggestion (use the Cookie Store API) is intentionally overridden here.

## Testing

- Added a regression assertion in `tests/login.spec.ts`: after landing on `/dashboard`, the `timezone` cookie must be set — proves `TimezoneSync` runs on all five browser projects (chromium, firefox, webkit, mobile Chrome/Safari).
- `pnpm lint` → exit 0
- `pnpm tsc --noEmit` → exit 0
- E2E to be validated by CI (not run locally due to a port-3000 conflict on the dev machine).

## Notes

- No server-side changes — `lib/timezone.ts`'s fallback chain and cookie validation are unchanged; the raw-IANA cookie format is preserved.
- Out of scope (deliberately deferred): adding an `error.tsx` boundary under `app/(app)/` so client errors don't nuke the whole shell.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced timezone detection and persistence to ensure your system timezone is accurately identified, compared with stored settings, and reliably maintained across sessions with improved security.

* **Tests**
  * Added automated test to verify that your timezone is correctly captured and persisted when you authenticate and access your dashboard.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->